### PR TITLE
Run rsync command in pull_rundir and push_rundir in synchronous mode

### DIFF
--- a/src/sjef/util/Job.cpp
+++ b/src/sjef/util/Job.cpp
@@ -51,8 +51,7 @@ std::tuple<bool, std::string, std::string> sjef::util::Job::push_rundir(int verb
   auto start_time = std::chrono::steady_clock::now();
   (*m_backend_command_server)("mkdir -p '" + m_remote_cache_directory + "'");
   const Shell& shell = Shell();
-  auto rsync_out = shell(command, verbosity);
-  shell.wait();
+  auto rsync_out = shell(command, true, ".", verbosity);
   if (verbosity > 1)
     m_project.m_trace(3 - verbosity)
         << "time for push_rundir() rsync "
@@ -78,8 +77,7 @@ std::tuple<bool, std::string, std::string> sjef::util::Job::pull_rundir(int verb
   m_project.m_trace(2 - verbosity) << "Pull rsync: " << command << std::endl;
   auto start_time = std::chrono::steady_clock::now();
   const Shell& shell = Shell();
-  auto rsync_out = shell(command, verbosity);
-  shell.wait();
+  auto rsync_out = shell(command, true, ".", verbosity);
   if (verbosity > 1)
     m_project.m_trace(3 - verbosity)
         << "time for pull_rundir() rsync "


### PR DESCRIPTION
Using shell.wait() is not effective to test for completion of rsync commands as it runs in background and the shell exits before it finishes.
Change to alternate functionality to run command in foreground.
Opened issue 216 to address root cause.