### PR TITLE
Use MSYS2 ssh for shell for remote execution

### DIFF
--- a/src/sjef/util/Shell.cpp
+++ b/src/sjef/util/Shell.cpp
@@ -15,6 +15,9 @@ Shell::Shell(std::string host, std::string shell) : m_host(std::move(host)), m_s
   if (!localhost()) {
     m_out.reset(new bp::ipstream);
     m_err.reset(new bp::ipstream);
+#ifdef WIN32
+  _putenv_s("PATH", "C:\\msys64\\usr\\bin;C:\\Windows\\System32\\OpenSSH");
+#endif
     m_process = bp::child(bp::search_path("ssh"), m_host, std::move(shell), "-l", bp::std_in<m_in, bp::std_err> * m_err,
                           bp::std_out > *m_out);
     if (!m_process.valid())


### PR DESCRIPTION
Possible fix for issue #250 if we want to use MSYS2 ssh for all functionality