### PR TITLE
rsync without shell

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ add_custom_target(_version.py
 
 if (WIN32)
     FetchContent_Declare(rsync
-            GIT_REPOSITORY https://github.com/molpro/windows-rsync
+            GIT_REPOSITORY https://github.com/molpro/cwrsync
             GIT_TAG main
     )
     FetchContent_MakeAvailable(rsync)

--- a/src/sjef/backends.md
+++ b/src/sjef/backends.md
@@ -29,7 +29,7 @@ The key/value pairs are normally specified through the library call to run the j
 Example:
 
 <!--- @cond DoNotRaiseWarning
---->
+-->
 ```xml
 <backends>
   <!-- there is a default template backend always added to the configuration file by the library
@@ -58,6 +58,6 @@ Example:
     />
 </backends>
 ```
-<!--- @endcond --->
+<!--- @endcond -->
 
 [//]: # ( @page backends sjef-project backends)

--- a/src/sjef/util/Job.cpp
+++ b/src/sjef/util/Job.cpp
@@ -99,7 +99,7 @@ std::tuple<bool, std::string, std::string> sjef::util::Job::push_rundir(int verb
   m_project.m_trace(2 - verbosity) << "Push rsync: " << command << std::endl;
   auto start_time = std::chrono::steady_clock::now();
   ensure_remote_cache_directory();
-  const Shell& shell = Shell();
+  const Shell& shell = Shell("localhost","");
   try {
     auto rsync_out = shell(command, true, ".", verbosity);
   } catch (const sjef::util::Shell::runtime_error& e) {
@@ -150,7 +150,7 @@ std::tuple<bool, std::string, std::string> sjef::util::Job::pull_rundir(int verb
     command += " -v";
   m_project.m_trace(2 - verbosity) << "Pull rsync: " << command << std::endl;
   auto start_time = std::chrono::steady_clock::now();
-  const Shell& shell = Shell();
+  const Shell& shell = Shell("localhost","");
   std::string rsync_out;
   try {
     rsync_out = shell(command, true, ".", verbosity);

--- a/src/sjef/util/Job.cpp
+++ b/src/sjef/util/Job.cpp
@@ -67,7 +67,7 @@ sjef::util::Job::Job(const sjef::Project& project)
         std::cout << "getenv(PATH) "<<getenv("PATH")<<std::endl;
         std::cout << "conda_prefix "<<conda_prefix<<std::endl;
         if (conda_prefix != NULL) {
-          _putenv_s("PATH", (std::string(conda_prefix) + "\\rsync;" + getenv("PATH")).c_str());
+          _putenv_s("PATH", (std::string(conda_prefix) + "\\rsync\\bin;" + getenv("PATH")).c_str());
         }
         std::cout << "getenv(PATH) "<<getenv("PATH")<<std::endl;
 #endif

--- a/src/sjef/util/Shell.h
+++ b/src/sjef/util/Shell.h
@@ -18,6 +18,11 @@ namespace sjef::util {
 class Shell {
 
 public:
+  /*!
+   * @brief Construct a shell instance
+   * @param host hostname passed to ssh. If "localhost", ssh will not be used.
+   * @param shell Shell command. If empty, then operator() will run commands directly and synchronously rather than in a shell.
+   */
   Shell(std::string host, std::string shell = "bash");
   Shell() : Shell("localhost") {}
   std::string operator()(const std::string& command, bool wait = true, const std::string& directory = ".",
@@ -62,6 +67,8 @@ private:
 
   bool localhost() const { return (m_host.empty() || m_host == "localhost"); }
 };
+
+std::vector<std::string> tokenise(const std::string& command);
 
 } // namespace sjef::util
 

--- a/test/test-Shell.cpp
+++ b/test/test-Shell.cpp
@@ -143,6 +143,7 @@ TEST(Shell, bad_command) {
 }
 
 TEST(Shell, no_shell) {
+#ifndef WIN32
   sjef::util::Shell comm("localhost", "");
   comm("ls '-d' .", true, ".", 0);
   EXPECT_EQ(comm.out(), ".");
@@ -152,6 +153,7 @@ TEST(Shell, no_shell) {
   comm("ls 'one two three'", true, ".", 0);
   EXPECT_EQ(comm.out(), "one two three");
   comm("rm -f 'one two three'", true, ".", 0);
+#endif
 }
 
 TEST(Shell, tokenise) {

--- a/test/test-Shell.cpp
+++ b/test/test-Shell.cpp
@@ -141,3 +141,29 @@ TEST(Shell, bad_command) {
     EXPECT_TRUE(caught);
   }
 }
+
+TEST(Shell, no_shell) {
+  sjef::util::Shell comm("localhost", "");
+  comm("ls '-d' .", true, ".", 0);
+  EXPECT_EQ(comm.out(), ".");
+//  std::cout << comm.out() << std::endl;
+  comm("touch 'one two three'", true, ".", 0);
+  EXPECT_EQ(comm.out(), "");
+  comm("ls 'one two three'", true, ".", 0);
+  EXPECT_EQ(comm.out(), "one two three");
+  comm("rm -f 'one two three'", true, ".", 0);
+}
+
+TEST(Shell, tokenise) {
+  std::map<std::string, std::vector<std::string>> tests;
+  tests["a b c"] = {"a", "b", "c"};
+  tests["'a b' c"] = {"a b", "c"};
+  tests["\"a b\" c"] = {"a b", "c"};
+  tests["\"ab\" c"] = {"ab", "c"};
+  tests["\"ab\"c"] = {"abc"};
+  tests["\"ab\"cd"] = {"abcd"};
+  tests["a\"b\"cd"] = {"abcd"};
+  for (const auto& [str, tokens] : tests) {
+    EXPECT_EQ(sjef::util::tokenise(str), tokens);
+  }
+}


### PR DESCRIPTION
- **sjef::util::Shell extended to support running a local command directly instead of in a shell. This used for rsync.**
- **not windows in test**
- **Use cwrsync on windows**
