### PR TITLE
Add cibuildwheel workflow for PyPI wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0   # setuptools_scm and LibraryManager both need tag history
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21
+        uses: pypa/cibuildwheel@v2.22
         env:
           CIBW_BEFORE_ALL_LINUX: >
             set -eux &&

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -60,6 +60,7 @@ jobs:
     environment: pypi
     permissions:
       id-token: write   # trusted publishing to PyPI, no API token needed
+      contents: read
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22
         env:
-          CIBW_MACOS_DEPLOYMENT_TARGET: "10.15"
+          CIBW_MACOS_DEPLOYMENT_TARGET: "11.0"
           CIBW_BEFORE_ALL_LINUX: >
             set -eux &&
             if command -v yum >/dev/null 2>&1; then

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22
         env:
-          CIBW_MACOS_DEPLOYMENT_TARGET: "11.0"
+          CIBW_MACOS_DEPLOYMENT_TARGET: 11.0
+          CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=11.0"
           CIBW_BEFORE_ALL_LINUX: >
             set -eux &&
             if command -v yum >/dev/null 2>&1; then

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,58 @@
+name: wheels
+
+on:
+  push:
+    tags: [ "[0-9]+.[0-9]+.[0-9]+" ]   # matches existing tag style, e.g. 1.45.4
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build_wheels:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
+          - os: macos-13      # Intel
+          - os: macos-14      # Apple Silicon
+          - os: windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # setuptools_scm and LibraryManager both need tag history
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.21
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
+
+  build_sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: pipx run build --sdist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  publish:
+    needs: [ build_wheels, build_sdist ]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # trusted publishing to PyPI, no API token needed
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,14 +26,12 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21
         env:
-          CIBW_BEFORE_BUILD: |
-            set -eux
-            # Install libxml2/libxslt development packages required to build lxml
-            # Works across manylinux variants by checking available package manager.
+          CIBW_BEFORE_BUILD: >
+            set -eux &&
             if command -v yum >/dev/null 2>&1; then
-              yum -y install libxml2-devel libxslt-devel
+              yum -y install libxml2-devel libxslt-devel;
             elif command -v apt-get >/dev/null 2>&1; then
-              apt-get update && apt-get install -y libxml2-dev libxslt1-dev
+              apt-get update && apt-get install -y libxml2-dev libxslt1-dev;
             fi
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21
         env:
-          CIBW_BEFORE_BUILD: >
+          CIBW_BEFORE_ALL_LINUX: >
             set -eux &&
             if command -v yum >/dev/null 2>&1; then
               yum -y install libxml2-devel libxslt-devel;

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22
         env:
+          CIBW_MACOS_DEPLOYMENT_TARGET: "10.15"
           CIBW_BEFORE_ALL_LINUX: >
             set -eux &&
             if command -v yum >/dev/null 2>&1; then

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,6 +25,16 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21
+        env:
+          CIBW_BEFORE_BUILD: |
+            set -eux
+            # Install libxml2/libxslt development packages required to build lxml
+            # Works across manylinux variants by checking available package manager.
+            if command -v yum >/dev/null 2>&1; then
+              yum -y install libxml2-devel libxslt-devel
+            elif command -v apt-get >/dev/null 2>&1; then
+              apt-get update && apt-get install -y libxml2-dev libxslt1-dev
+            fi
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,7 +31,9 @@ jobs:
             if command -v yum >/dev/null 2>&1; then
               yum -y install libxml2-devel libxslt-devel;
             elif command -v apt-get >/dev/null 2>&1; then
-              apt-get update && apt-get install -y libxml2-dev libxslt1-dev;
+                        apt-get update && apt-get install -y libxml2-dev libxslt1-dev;
+            elif command -v apk >/dev/null 2>&1; then
+              apk add --no-cache libxml2-dev libxslt-dev;
             fi
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,8 +14,8 @@ jobs:
         include:
           - os: ubuntu-latest
           - os: ubuntu-24.04-arm
-          - os: macos-13      # Intel
-          - os: macos-14      # Apple Silicon
+          - os: macos-15-intel      # Intel
+          - os: macos-latest      # Apple Silicon
           - os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,16 @@ set(PROGRAM_NAME "sjef-program")
 
 if (MSVC)
     add_compile_options(/EHsc /permissive-)
+
+    # Define Windows target architecture
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        add_compile_options(/D_WIN64)
+    else()
+        add_compile_options(/D_WIN32)
+    endif()
+
+    # Define minimum Windows version
+    add_compile_definitions(_WIN32_WINNT=0x0601)
 endif ()
 
 option(BUILD_PYTHON "Whether to build the Python bindings or not" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ option(BUILD_PROGRAM "Whether to build sjef command-line program or not" ON)
 
 project(sjef LANGUAGES CXX C VERSION ${PROJECT_VERSION})
 set(SJEF_VERSION ${PROJECT_VERSION_FULL})
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum macOS deployment target")
 
 set(PROGRAM_FILENAME "sjef")
 set(PROGRAM_NAME "sjef-program")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,6 @@ skip = ["pp*"]
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
+
+[tool.cibuildwheel.macos]
+deployment-target = "10.15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [ "regex", "lxml", ]
 dynamic = [ "version", ]
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [tool.scikit-build]
 cmake.source-dir = "."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,3 @@ skip = ["pp*"]
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
-
-[tool.cibuildwheel.macos]
-macos-deployment-target = "10.15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,6 @@ skip = ["pp*"]
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
+
+[tool.scikit-build.cmake.define]
+CMAKE_OSX_DEPLOYMENT_TARGET = "11.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [ "regex", "lxml", ]
 dynamic = [ "version", ]
 readme = "README.md"
 license = "MIT"
+requires-python = ">=3.9"
 
 [tool.scikit-build]
 cmake.source-dir = "."
@@ -34,6 +35,7 @@ write_to = "src/pysjef/_version.py"
 [tool.cibuildwheel]
 build-verbosity = 1
 test-command = "python -c \"import pysjef; print(pysjef.__version__)\""
+skip = ["pp*"]
 
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux_2_28"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,4 +42,4 @@ manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.macos]
-deployment-target = "10.15"
+macos-deployment-target = "10.15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ sdist.include = ["src/pysjef/_version.py"]
 [tool.scikit-build.cmake.define]
 BUILD_PYTHON = "ON"
 BUILD_DOCUMENTATION = "OFF"
+BUILD_PROGRAM = "OFF"
 
 [[tool.dynamic-metadata]]
 field = "version"
@@ -29,3 +30,11 @@ provider = "scikit_build_core.metadata.setuptools_scm"
 
 [tool.setuptools_scm]
 write_to = "src/pysjef/_version.py"
+
+[tool.cibuildwheel]
+build-verbosity = 1
+test-command = "python -c \"import pysjef; print(pysjef.__version__)\""
+
+[tool.cibuildwheel.linux]
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ wheel.packages = ["src/pysjef"]
 sdist.include = ["src/pysjef/_version.py"]
 
 [tool.scikit-build.cmake.define]
+CMAKE_OSX_DEPLOYMENT_TARGET = "11.0"
 BUILD_PYTHON = "ON"
 BUILD_DOCUMENTATION = "OFF"
 BUILD_PROGRAM = "OFF"
@@ -40,6 +41,3 @@ skip = ["pp*"]
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
-
-[tool.scikit-build.cmake.define]
-CMAKE_OSX_DEPLOYMENT_TARGET = "11.0"

--- a/src/sjef/util/Job.cpp
+++ b/src/sjef/util/Job.cpp
@@ -12,8 +12,10 @@
 #include <stdlib.h>
 #include <string>
 #if defined(WIN32) || defined(__WIN64)
-#ifdef _M_AMD64
+#if defined(_M_AMD64) || defined(_M_X64)
 #define _AMD64_
+#elif defined(_M_IX86)
+#define _X86_
 #endif
 #include <handleapi.h>
 #include <processthreadsapi.h>


### PR DESCRIPTION
Adds a cibuildwheel-based workflow (.github/workflows/wheels.yml) to build wheels for Linux (x86_64/aarch64), macOS (x86_64/arm64), and Windows, plus an sdist, and publish to PyPI via trusted publishing on tag pushes. Also sets BUILD_PROGRAM=OFF for wheel builds since the CLI isn't shipped in the wheel.