### PR TITLE
Fix Windows PATH-separator regression in executable() (regressed 1.44.2->1.44.5)

### DIFF
--- a/src/sjef/util/Shell.cpp
+++ b/src/sjef/util/Shell.cpp
@@ -42,9 +42,14 @@ static std::string executable(const std::string& command) {
   if (fs::path(command).is_absolute())
     return command;
   else {
+#ifdef WIN32
+    constexpr char path_separator = ';';
+#else
+    constexpr char path_separator = ':';
+#endif
     std::stringstream path{std::string{getenv("PATH")}};
     std::string elem;
-    while (std::getline(path, elem, ':')) {
+    while (std::getline(path, elem, path_separator)) {
       auto resolved = elem / fs::path{command};
       if (fs::is_regular_file(resolved))
         return resolved.string();


### PR DESCRIPTION
The manual PATH-search fallback in executable() (util/Shell.cpp)
hardcoded ':' as the PATH entry separator. This was previously an
unused fallback path (a use_boost_search_path constexpr toggle
defaulted to using bp::search_path() instead, which correctly handles
platform-specific separators), but became the *only* code path once
boost::process's search_path was removed (commits removing
boost::filesystem/boost::process dependencies between 1.44.2 and
1.44.5).

':' is correct for Unix PATH entries, but Windows uses ';'. Splitting
a Windows PATH string like
'C:\Users\...;C:\Windows\System32;...' on ':' produces garbage
fragments -- it splits at every drive-letter colon -- so no command
(e.g. 'bash', used to launch jobs via
'bash -c (( mpiexec ... ) & echo @@@JOBNUMBER  1>&2)') can ever be
resolved to a valid path. executable() then returns an empty string,
and the caller's CreateProcess fails with 'The system cannot find the
file specified.'

Fixed by selecting the PATH separator based on platform (';' on
WIN32, ':' otherwise), matching the file's existing #ifdef WIN32
convention used a few lines above for the ssh executable path, and
matching the standard convention for this (e.g. Python's own
os.pathsep).
