### PR TITLE
Release the GIL during Project.run() and Project.kill()

### DIFF
--- a/src/pysjef/project_wrapper.pxd
+++ b/src/pysjef/project_wrapper.pxd
@@ -31,11 +31,11 @@ cdef extern from "sjef/sjef.h" namespace "sjef":
         string file_contents(string, string) except +
         string file_contents(string) except +
         string input_from_output() except +
-        bool run(int, bool, bool, string) except +
-        bool run(string, int, bool, bool, string) except +
+        bool run(int, bool, bool, string) except + nogil
+        bool run(string, int, bool, bool, string) except + nogil
         bool run_needed(int) except +
         void run_directory_new() except +
-        void kill() except +
+        void kill() except + nogil
         void wait() except +
         void wait(unsigned int) except +
         status status() except +

--- a/src/pysjef/project_wrapper.pyx
+++ b/src/pysjef/project_wrapper.pyx
@@ -190,13 +190,26 @@ cdef class ProjectWrapper:
         deref(self.c_project).trash()
 
     def run(self, backend=None, verbosity=0, bool force=False, bool wait=False, options=""):
+        # For a remote backend this blocks on network I/O (pushing the run directory via
+        # rsync/ssh), which can take several seconds. It touches only the C++ Project object,
+        # never the Python C-API, so it's safe to release the GIL for the call's duration -
+        # otherwise a caller who has moved this onto a background thread to keep a GUI
+        # responsive gets no benefit, since the call would still hold the GIL for its whole
+        # duration and starve every other Python thread, including the one running the GUI's
+        # own event loop.
         cdef int v = verbosity
         cdef string bend
+        cdef string opts = options.encode('utf-8')
+        cdef Project* proj = self.c_project.get()
+        cdef bool result
         if backend is None:
-            return deref(self.c_project).run(v, force, wait, options.encode('utf-8'))
+            with nogil:
+                result = deref(proj).run(v, force, wait, opts)
         else:
             bend = backend.encode('utf-8')
-            return deref(self.c_project).run(bend, v, force, wait, options.encode('utf-8'))
+            with nogil:
+                result = deref(proj).run(bend, v, force, wait, opts)
+        return result
 
     def run_needed(self, int verbosity = 0):
         return deref(self.c_project).run_needed(verbosity)
@@ -220,7 +233,12 @@ cdef class ProjectWrapper:
 
     def kill(self):
         """Kill the job started by ``run``"""
-        deref(self.c_project).kill()
+        # Same reasoning as run(): for a remote backend this sends the kill command over
+        # ssh and blocks waiting for it, and for a local job it does a synchronous 1s sleep
+        # to let the script clean up. Pure C++/no Python C-API, so safe to release the GIL.
+        cdef Project* proj = self.c_project.get()
+        with nogil:
+            deref(proj).kill()
 
     def wait(self, max_microseconds = None):
         """Wait for completion of the job started by ``run``"""


### PR DESCRIPTION
## Summary
- `run()` blocks on network I/O for a remote backend (`Job::push_rundir()` pushes the new run directory via rsync/ssh), and `kill()` sends the kill command over ssh and waits for it - both can take several seconds. Neither touches the Python C-API internally, so the Cython bindings can safely release the GIL for the call's duration.
- Without this, a caller who moves `project.run()`/`kill()` onto a background thread to keep a GUI responsive (e.g. iMolpro) gets no real benefit: the call still holds the GIL for its whole duration and starves every other Python thread, including the one running the GUI's own event loop.
- `project_wrapper.pxd`: marked both `Project::run(...)` overloads and `Project::kill()` `nogil` in the `cdef extern` declarations.
- `project_wrapper.pyx`: wrapped the actual calls in `with nogil:`, doing the Python-string encoding and grabbing a raw `Project*` beforehand (those still need the GIL). `except +` continues to work correctly under `nogil` - Cython reacquires the GIL just long enough to translate a C++ exception into a Python one.

## Caveat for callers
Releasing the GIL means genuinely concurrent C++ execution into the same `Project` instance is now possible from multiple threads, where previously the GIL happened to serialize it. `Project` only has an internal mutex around property writes (`m_property_set_mutex`), not a general one covering `run()`/`status()`/`kill()` against each other. A caller invoking these from more than one thread on the same `Project` instance needs its own external lock (iMolpro does this via `ProjectWindow._run_lock`).

## Test plan
- [x] Ran the `.pyx` through `cython --cplus -3` directly and inspected the generated C++: confirmed `Py_UNBLOCK_THREADS`/`Py_BLOCK_THREADS` are emitted around both `run()` call sites and the `kill()` call site, with the GIL correctly reacquired via `PyGILState_Ensure`/`Release` in the `except +` exception path.
- [ ] Full native build (CMake + Boost, needs network fetch) not attempted in this environment.
- [ ] Manual verification against a real remote backend: confirm the app-level freeze during `Run job`/`Kill` is resolved (this is the motivating change - see molpro/iMolpro#384).

🤖 Generated with [Claude Code](https://claude.com/claude-code)