### PR TITLE
Keep status as waiting, not unknown, during job-completion grace period

### DIFF
--- a/src/sjef/util/Job.cpp
+++ b/src/sjef/util/Job.cpp
@@ -385,12 +385,17 @@ void Job::poll_job(int verbosity) {
           // cleanup bug below: that still requires m_seen_running, so at worst a fast-failing job's
           // remote cache directory is left behind instead of being cleaned up immediately.
           status = completed;
+        } else {
+          // Still within the grace period for a freshly submitted job that has not yet been confirmed
+          // running. Report "waiting" rather than the raw "unknown" reading: callers (e.g. pysjef's
+          // Project.wait(), which only loops on "running"/"waiting") treat "unknown" as a terminal,
+          // stop-waiting state, so leaking a merely-transient "unknown" here would make them give up
+          // before this grace period has had a chance to resolve to a real answer. Do NOT infer
+          // completion straight from m_initial_status == waiting -- that value just means a submission
+          // is in progress (see Job::run()), so a single "unknown" read here only means we haven't
+          // caught up with the freshly submitted job yet.
+          status = waiting;
         }
-        // else: still within the grace period for a freshly submitted job that has not yet been
-        // confirmed running; leave status as unknown (m_initial_status == waiting covers this) and
-        // retry on the next cycle. Do NOT infer completion straight from m_initial_status == waiting --
-        // that value just means a submission is in progress (see Job::run()), so a single "unknown"
-        // read here only means we haven't caught up with the freshly submitted job yet.
       } else {
         m_unconfirmed_polls = 0;
       }


### PR DESCRIPTION
## Summary
- Follow-up to 95b1c47, which gave a freshly submitted job a short grace
  period (a few polls) before `poll_job()` concludes it must have
  completed, instead of jumping to that conclusion on the very first
  "unknown" status read.
- That grace period could leave the persisted status as `unknown` while
  still undecided. `pysjef`'s `Project.wait()` only loops on
  `"running"`/`"waiting"`, not `"unknown"` (unlike the C++
  `Project::wait()`, which already handles `unknown` correctly), so it
  was returning the moment it observed that transient reading -- before
  `poll_job()` had a chance to resolve it. This broke
  `test_run_local`/`test_run_ssh` in CI.
- Fix: report `waiting` instead of the raw `unknown` reading throughout
  the grace period. Only the two genuinely-resolved outcomes (job was
  seen running and is now gone, or the grace period is exhausted) ever
  surface as `completed`.

## Test plan
- [x] `python -m pytest src/pysjef/test/` -- 15 passed, run 5x with no
      flakiness
- [x] Manual end-to-end repro against a real remote backend (job
      submission, status polling, output sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)