### PR TITLE
Fix backend-config sync silently dropping run_jobnumber/status_running/status_waiting edits

### DIFF
--- a/src/sjef/sjef-backend.cpp
+++ b/src/sjef/sjef-backend.cpp
@@ -27,7 +27,10 @@ std::string sjef::Backend::str() const {
             << " host=\"" << host << "\""
             << " cache=\"" << cache << "\""
             << " run_command=\"" << run_command << "\""
+            << " run_jobnumber=\"" << run_jobnumber << "\""
             << " status_command=\"" << status_command << "\""
+            << " status_running=\"" << status_running << "\""
+            << " status_waiting=\"" << status_waiting << "\""
             << " kill_command=\"" << kill_command << "\"";
     return ss.str();
 }


### PR DESCRIPTION
## Summary
- `sjef::operator==(Backend, Backend)` compares `Backend::str()`, which
  omitted `run_jobnumber`, `status_running`, and `status_waiting`.
- `sync_backend_config_file()` uses this equality to decide whether the
  `xml` and `yaml` backend config files have diverged and need
  re-syncing. Two configs differing only in one of these three fields
  were treated as identical, so an edit to just one of them (in
  whichever format isn't currently preferred -- `yaml` by default) was
  silently discarded on the next load instead of being propagated.
- This surfaced concretely with a batch-submission backend (`run_command`
  wrapping a queueing script like `sbatch`): its `run_jobnumber` needs a
  custom regex (`"Submitted batch job *([0-9]+)"`, per `backends.md`) to
  capture the real batch job number from the submission command's
  output, instead of falling back to capturing the PID of the submission
  wrapper's own shell process (which isn't the job that keeps running,
  so status polling never found it and output was never synced back).
  Editing `run_jobnumber` to add that regex had no effect until this
  fix, because the edit never made it past the equality check.

## Test plan
- [x] `python -m pytest src/pysjef/test/` -- 15 passed
- [x] Manual end-to-end repro against a real Slurm-batch backend: edited
      `run_jobnumber` in the `xml` config, confirmed it now propagates to
      `yaml`, and confirmed the job number, status (waiting -> running ->
      completed), and output files (`.xml`, `.out`) all now track the
      real batch job correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)