### PR TITLE
Fix Windows: suppress console window flash for spawned ssh process

### DIFF
--- a/src/sjef/util/Shell.cpp
+++ b/src/sjef/util/Shell.cpp
@@ -50,7 +50,7 @@ Shell::Shell(std::string host, std::string shell) : m_host(std::move(host)), m_s
     auto ssh = executable("ssh");
 #endif
     m_process =
-        bp::child(ssh, m_host, std::move(shell), "-l", bp::std_in<m_in, bp::std_err> * m_err, bp::std_out > *m_out);
+        bp::child(ssh, m_host, std::move(shell), "-l", bp::std_in<m_in, bp::std_err> * m_err, bp::std_out > *m_out SJEF_NO_CONSOLE_WINDOW);
     //    std::cout << "ssh is"<<ssh<<", "<<m_process.valid()<<", "<<m_process.running()<<std::endl;
     if (!m_process.valid() || !m_process.running())
       throw Shell::runtime_error("Spawning run process has failed");


### PR DESCRIPTION
## Summary
- The `SJEF_NO_CONSOLE_WINDOW` fix landed in 82c35ab6 for the local `nohup`/shell child processes, but missed the persistent `ssh` child process spawned in `Shell::Shell()` for remote hosts.
- Since a new `Shell` (and thus a new ssh process) is created per remote job submission / status check, every one of them flashed a console window on Windows.
- Apply the same `SJEF_NO_CONSOLE_WINDOW` (`bp::windows::create_no_window`) flag to that `bp::child(ssh, ...)` construction.

## Test plan
- [ ] Build on Windows and submit a job to a remote backend; confirm no console window appears (previously one flashed per ssh spawn/status check)
- [ ] Confirm remote job submission/monitoring/output retrieval still work correctly on Windows