### PR TITLE
Fix run_needed() false positive when input has whitespace-only blank lines

### DIFF
--- a/src/sjef/sjef.cpp
+++ b/src/sjef/sjef.cpp
@@ -557,16 +557,24 @@ bool Project::run_needed(int verbosity) const {
       << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time).count()
       << std::endl;
   if (run_input_hash.empty()) { // if there's no input hash, look at the xml file instead
-    const auto input_file_contents = std::regex_replace(
-        std::regex_replace(std::regex_replace(std::regex_replace(file_contents("inp", "", -1), std::regex{"\r"}, ""),
-                                              std::regex{" *\n\n*"}, "\n"),
-                           std::regex{"\n$"}, ""),
-        std::regex{"^\n*"}, "");
+    // Molpro drops blank (or whitespace-only) lines entirely from the <input> section of
+    // the xml stream, so both sides of the comparison must have their blank lines collapsed
+    // in the same way, regardless of how many there are or whether they contain whitespace.
+    auto normalise = [](std::string text) {
+      text = std::regex_replace(text, std::regex{"\r"}, "");
+      text = std::regex_replace(text, std::regex{"[ \t]*\n"}, "\n"); // strip trailing whitespace on each line
+      text = std::regex_replace(text, std::regex{"\n\n+"}, "\n");   // collapse runs of blank lines
+      text = std::regex_replace(text, std::regex{"^\n+"}, "");      // strip leading blank lines
+      text = std::regex_replace(text, std::regex{"\n$"}, "");       // strip trailing newline
+      return text;
+    };
+    const auto input_file_contents = normalise(file_contents("inp", "", -1));
+    const auto output_input_contents = normalise(input_from_output());
     m_trace(3 - verbosity) << "There's no run_input_hash, so compare output and input: "
-                           << (input_file_contents != input_from_output()) << "\ninput_file:\n"
+                           << (input_file_contents != output_input_contents) << "\ninput_file:\n"
                            << input_file_contents << "@\ninput_from_output:\n"
-                           << input_from_output() << "@" << std::endl;
-    return (input_file_contents != input_from_output());
+                           << output_input_contents << "@" << std::endl;
+    return (input_file_contents != output_input_contents);
   }
   {
     m_trace(3 - verbosity) << "sjef::Project::run_needed, input_hash =" << input_hash() << std::endl;

--- a/test/test-sjef-molpro.cpp
+++ b/test/test-sjef-molpro.cpp
@@ -176,6 +176,19 @@ TEST_F(test_sjef_molpro, run_needed) {
 
 }
 
+// https://github.com/molpro/sjef/issues/321: Molpro omits blank (including whitespace-only)
+// lines from the <input> section of the xml stream, so a run should not be considered
+// necessary just because the input file has a blank line that contains only whitespace.
+TEST_F(test_sjef_molpro, run_needed_whitespace_only_blank_line) {
+  sjef::Project He("He.molpro");
+  auto copy = testfile("HecopyBlankLine.molpro");
+  He.copy(copy, false, false, false, 999);
+  sjef::Project Hecopy(copy);
+  EXPECT_FALSE(Hecopy.run_needed());
+  { std::ofstream(Hecopy.filename("inp")) << "geometry={He}\nrhf   \nmp2\n   \nccsd\n"; }
+  EXPECT_FALSE(Hecopy.run_needed());
+}
+
 TEST_F(test_sjef_molpro, failure) {
   if (sjef::util::Shell::local_asynchronous_supported()) {
     sjef::Project p(testfile("test.molpro"));


### PR DESCRIPTION
## Summary
Fixes #321.

Molpro drops blank lines entirely from the `<input>` section of its xml stream, so `Project::run_needed()`'s text comparison collapses runs of blank lines in the saved input file to match, before comparing against `input_from_output()`.

The collapsing regex (`" *\n\n*"` -> `"\n"`) only correctly handles blank lines made purely of newlines. A "blank" line that contains trailing whitespace (e.g. a stray space or tab left by an editor) produces two separate, non-adjacent regex matches instead of one contiguous match, so the run of newlines doesn't fully collapse — leaving an extra `\n` that doesn't exist in the xml-reconstructed input. That spurious difference made `run_needed()` incorrectly report `true` (rerun needed) even though nothing meaningful had changed.

The fix replaces the single combined regex with a small `normalise()` helper that:
1. strips `\r`,
2. strips trailing whitespace from every line (so a whitespace-only line becomes a bare `\n`),
3. collapses the now-contiguous runs of `\n` into one,
4. strips leading/trailing blank lines,

and applies the same normalisation to both sides of the comparison (previously only the input-file side was normalised).

## Test plan
- Added `test_sjef_molpro.run_needed_whitespace_only_blank_line` in `test/test-sjef-molpro.cpp`, which reproduces the reported scenario using the existing `He.molpro` fixture: a copy of a completed project whose input file is rewritten with a blank line containing only spaces between two directives. Verified this test fails (`run_needed()` returns `true`) against the pre-fix code and passes after the fix.
- Ran the full `test-sjef-molpro` suite (`spawn_many_molpro`, `molpro_workflow`, `input_from_output`, `run_needed`, `run_needed_whitespace_only_blank_line`, `failure`) locally against a real `molpro` executable; all 6 pass.