### PR TITLE
Fix Project docstring field lists, and fix broken CI Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,15 @@ RUN . /opt/conda/etc/profile.d/conda.sh && conda install -y conda-anaconda-tos &
 
 RUN  . /opt/conda/etc/profile.d/conda.sh && conda install -c conda-forge -y python 'numpy>=1.17' 'libboost-devel>=1.90' 'pugixml>=1.10' 'cython>=3.0' 'lxml>=4.0' pip regex c-compiler cxx-compiler ghostscript 'pytest>=7' 'cmake>=3.27' 'make>=4' scipy
 
+# conda-forge's c-compiler/cxx-compiler only provide an arch-prefixed ar
+# (e.g. x86_64-conda-linux-gnu-ar), not a plain `ar` on PATH, and don't set
+# $AR either. CMake's compiler-id detection can't infer the prefix from an
+# unprefixed `gcc`/`cc`, so CMAKE_AR ends up NOTFOUND and linking any static
+# library (e.g. the bundled libyaml) fails. Symlink whatever ar gcc itself
+# resolves to, which is correct for whichever architecture this is built on.
+RUN . /opt/conda/etc/profile.d/conda.sh && conda activate base \
+ && ln -sf "$(gcc -print-prog-name=ar)" /opt/conda/bin/ar
+
 ENV CONDA_PREFIX=/opt/conda
 
 RUN apt-get update

--- a/src/pysjef/project.py
+++ b/src/pysjef/project.py
@@ -201,6 +201,7 @@ class Project(Node):
     def run(self, backend=None, verbosity=0, force=False, wait=False, options=""):
         """
         Start a sjef job
+
         :param backend: name of the backend
         :param verbosity: If >0, show underlying processing
         :param force: whether to force submission of job even if run_needed() reports that it's unnecessary
@@ -215,6 +216,7 @@ class Project(Node):
     def run_needed(self, verbosity=0):
         """
         Check weather the job has changed since the previous run and needs to be rerun
+
         :return: True/False
         """
         return self._project_wrapper.run_needed(verbosity)
@@ -222,6 +224,7 @@ class Project(Node):
     def run_directory_new(self):
         """
         Check whether the job has changed since the previous run and needs to be rerun
+
         :return: True/False
         """
         self._project_wrapper.run_directory_new()
@@ -229,6 +232,7 @@ class Project(Node):
     def wait(self, max_epoch=.005):
         """
         Wait unconditionally for status() to return neither 'waiting' nor 'running'
+
         :param max_epoch: maximum time to wait between checking status (seconds)
         """
         epoch = 0.001
@@ -273,6 +277,7 @@ class Project(Node):
     def parse(self, force=False, **options):
         """
         Parse the output file and save resultant node as a child
+
         :param force: reparse the output
         """
         if not force and len(self.children) == 1:
@@ -290,6 +295,7 @@ class Project(Node):
     def import_input(self, fpath):
         """
         Copy file into the project as input file, or write string to input file
+
         :param fpath: path to input file
         """
         fpath = Path(fpath)
@@ -299,6 +305,7 @@ class Project(Node):
     def write_input(self, content):
         """
         Create an input file with content specified as a string
+
         :param content: string with content for the input file
         """
         self.write_file(self.name + '.inp', content)
@@ -371,6 +378,7 @@ class Project(Node):
     def refresh_backends(self):
         """
         Reload the backends from the configuration file
+
         :return:
         """
         return self._project_wrapper.refresh_backends()
@@ -378,6 +386,7 @@ class Project(Node):
     def backend_get(self, backend, key):
         """
         Obtain the value of a field in the backend
+
         :param backend:
         :param key:
         :return:


### PR DESCRIPTION
## Summary
- reST needs a blank line before a field list to parse `:param:`/`:return:` as separate fields rather than as part of the preceding prose paragraph. `run()`, `run_needed()`, `run_directory_new()`, `wait()`, `parse()`, `import_input()`, `write_input()`, `refresh_backends()` and `backend_get()` in `src/pysjef/project.py` were all missing that blank line, so their fields were rendering as one squashed paragraph. Found while wiring `pysjef.project.Project`'s existing docstrings into pymolpro's published Sphinx docs (molpro/pymolpro#165, companion PR molpro/pymolpro#166) — this is what makes those docstrings actually readable once they're `:inherited-members:`-included there.
- **Also fixes the CI failure on this PR** (`cmake-build`/`unix-python`, `CMAKE_AR-NOTFOUND` when linking the bundled `libyaml`), which turned out to be unrelated to the docstring change: the `ghcr.io/molpro/sjef` build image was rebuilt on 2026-08-14 against unpinned conda-forge, and its `c-compiler`/`cxx-compiler` (2.0.0) now install `gcc`/`cc` unprefixed while only providing an arch-prefixed `ar` (e.g. `x86_64-conda-linux-gnu-ar`) with no `$AR` set — CMake can't infer the prefix from an unprefixed compiler name, so `CMAKE_AR` never resolves. Fixed in `docker/Dockerfile` by symlinking whatever `gcc -print-prog-name=ar` itself resolves to as plain `ar`, which is portable across architectures since it's derived from the compiler actually installed rather than hardcoded.
  - Verified by pulling `ghcr.io/molpro/sjef:latest` for both `linux/amd64` and `linux/arm64` and reproducing the failure, then building this Dockerfile locally and running the full CMake build (including the Cython extension) to completion on both architectures.
  - **Note:** because `docker-publish.yml` only rebuilds/republishes the image on `push` (not `pull_request`), and `build-and-test.yml` always pulls `ghcr.io/molpro/sjef:latest`, this PR's own CI checks will keep failing against the *old* broken image until this Dockerfile change lands on `master` and republishes `latest`.

## Test plan
- [ ] Build docs (or run `python -m sphinx` against a stub `autoclass:: pysjef.project.Project`) and confirm `run()` etc. now render as a proper parameter list instead of one paragraph
- [x] Reproduced the CI failure locally against `ghcr.io/molpro/sjef:latest` (both architectures) and confirmed the Dockerfile fix resolves it end-to-end (full CMake + Cython build succeeds)
- [ ] CI goes green once this is merged and the image is republished

🤖 Generated with [Claude Code](https://claude.com/claude-code)