### PR TITLE
Fix Windows: suppress console window flash in remaining local spawn paths

### DIFF
--- a/src/sjef/util/Shell.cpp
+++ b/src/sjef/util/Shell.cpp
@@ -171,9 +171,9 @@ void Shell::run_local_sync(const std::string& command, const std::string& direct
     if (!tokens.empty())
       tokens[0] = executable(tokens[0]);
     if (out == "/dev/null" and err == "/dev/null")
-      m_process = bp::child(tokens, bp::std_out > *m_out, bp::std_err > *m_err);
+      m_process = bp::child(tokens, bp::std_out > *m_out, bp::std_err > *m_err SJEF_NO_CONSOLE_WINDOW);
     else
-      m_process = bp::child(tokens, bp::std_out > out, bp::std_err > err);
+      m_process = bp::child(tokens, bp::std_out > out, bp::std_err > err SJEF_NO_CONSOLE_WINDOW);
     m_job_number = m_process.id();
   } else {
     auto shell_path = executable(m_shell);
@@ -415,7 +415,7 @@ bool Shell::running() const {
     return m_process.running();
   bp::ipstream out;
   auto command = std::string{"ps -l -p "} + std::to_string(m_job_number) + "; echo $?";
-  auto proc = bp::child(std::vector<std::string>{"/bin/sh", "-c", command}, bp::std_out > out);
+  auto proc = bp::child(std::vector<std::string>{"/bin/sh", "-c", command}, bp::std_out > out SJEF_NO_CONSOLE_WINDOW);
   proc.wait();
   std::string line;
   bool result = false;


### PR DESCRIPTION
## Summary
- #320 added `SJEF_NO_CONSOLE_WINDOW` to the persistent ssh child process, but two other local `bp::child` spawns in `Shell.cpp` were still missing it:
  - The no-shell direct-exec branch of `run_local_sync()` (used when `Shell` is constructed with an empty shell string, e.g. `Shell("localhost", "")`). This is exactly the path `Job::push_rundir()`/`pull_rundir()` use to run `rsync` when pushing/pulling a remote job's run directory — so **every remote job submission still flashed a console window here even after #320**, which is almost certainly what's still being observed on Windows.
  - The local `ps -l -p ...` status check inside `running()`.
- Apply the same `SJEF_NO_CONSOLE_WINDOW` flag to both.

## Test plan
- [ ] Build on Windows and submit a job to a remote backend; confirm no console window appears during rsync push/pull or ssh connection
- [ ] Confirm remote job submission/monitoring/output retrieval still work correctly on Windows