### PR TITLE
Improve reliability of remote job launch, sync, and polling

### DIFF
--- a/src/sjef/util/Job.cpp
+++ b/src/sjef/util/Job.cpp
@@ -460,7 +460,18 @@ void Job::poll_job(int verbosity) {
         m_unconfirmed_polls = 0;
       }
       m_trace(4 - verbosity) << "got status " << status << std::endl;
-      pull_rundir(verbosity);
+      try {
+        pull_rundir(verbosity);
+      } catch (const std::exception& e) {
+        // A failed sync here (e.g. the remote host/session was briefly unresponsive) must not be
+        // allowed to propagate: this whole function runs on a detached std::async thread that
+        // nothing ever calls get() on, so an uncaught exception here silently kills polling for
+        // good, leaving status stuck at whatever it last was (typically "running"/"waiting") and
+        // an external caller like pysjef's Project.wait() looping forever with no error at all.
+        // Log and retry on the next cycle instead -- exactly as if this cycle's pull had simply
+        // seen nothing new.
+        m_trace(-verbosity) << "pull_rundir() failed during polling, will retry: " << e.what() << std::endl;
+      }
       // Don't publish a terminal status (completed/killed) for a remote job yet: the block below
       // this loop still has to pull the run directory one or more times more, compare manifests
       // against the remote cache, and remove that remote cache -- all further I/O against this
@@ -480,7 +491,14 @@ void Job::poll_job(int verbosity) {
         if (m_closing or status == completed or m_killed) {
           using namespace std::literals::chrono_literals;
           std::this_thread::sleep_for(10ms);
-          pull_rundir(verbosity);
+          try {
+            pull_rundir(verbosity);
+          } catch (const std::exception& e) {
+            // Same reasoning as above: don't let a failed final pull abort the function before it
+            // reaches the terminal set_status() below (or the cleanup block, which retries the pull
+            // anyway). Losing this one pull is recoverable; losing the terminal status is not.
+            m_trace(-verbosity) << "final pull_rundir() before break failed: " << e.what() << std::endl;
+          }
           break;
         }
       }
@@ -500,44 +518,58 @@ void Job::poll_job(int verbosity) {
   // too in that case, so cleanup only fires once we've actually confirmed the job was alive.
   if (!localhost() and m_backend_command_server != nullptr and
       (status == killed or (status == completed and m_seen_running))) {
-    m_backend_command_server.reset(new Shell(m_backend.host)); // so that any zombie is resolved or similar
-    m_trace(4 - verbosity) << "Pull run directory at end of job " << std::endl;
-    m_trace(4 - verbosity) << Shell()("echo local rundir;ls -lta '" + m_project.filename("", "", 0).string() + "'")
-                           << std::endl;
-    m_trace(4 - verbosity) << "remote cache directory: " << m_remote_cache_directory << std::endl;
-    m_trace(4 - verbosity) << (*m_backend_command_server)("echo remote cache;ls -lta '" + m_remote_cache_directory +
-                                                          "' 2>&1")
-                           << std::endl;
-    auto rundir_result = pull_rundir(verbosity);
-    m_trace(4 - verbosity) << Shell()("echo local rundir;ls -lta '" + m_project.filename("", "", 0).string() + "'")
-                           << std::endl;
-    m_trace(4 - verbosity) << (*m_backend_command_server)("echo remote cache;ls -lta '" + m_remote_cache_directory +
-                                                          "'  2>&1")
-                           << std::endl;
-    auto remote_manifest = vector_to_set(util::splitString(
-        (*m_backend_command_server)("ls -1 '" + m_remote_cache_directory + "' 2>&1 | grep -v Info.plist"), '\n'));
-    auto local_manifest = vector_to_set(util::splitString(
-        Shell()("ls -1 '" + m_project.filename("", "", 0).string() + "' 2>&1 | grep -v Info.plist"), '\n'));
-    //    std::cout << "rundir_result " << std::get<0>(rundir_result) << std::endl;
-    if (!std::get<0>(rundir_result) or remote_manifest == local_manifest) {
-      {
-        m_trace(4 - verbosity) << "remove run directory " + m_remote_cache_directory + " at end of job " << std::endl;
-        auto slash = m_remote_cache_directory.rfind("/");
-        (*m_backend_command_server)("cd '" + m_remote_cache_directory.substr(0, slash) + "' && rm -rf '" +
-                                    m_remote_cache_directory.substr(slash + 1) + "'");
+    // This whole block is best-effort: it can fail (a timed-out pull, an unresponsive remote ls/rm) for
+    // exactly the same reasons a mid-poll sync can, and for exactly the same reason as the try/catches
+    // around pull_rundir() above, none of that may be allowed to propagate out of this function. This
+    // is the *last* code before the terminal set_status() below; leaving the remote cache behind
+    // undeleted (it can be cleaned up by a later Job for the same project, or manually) is a much
+    // smaller problem than never publishing a terminal status at all and hanging every external caller
+    // forever.
+    try {
+      m_backend_command_server.reset(new Shell(m_backend.host)); // so that any zombie is resolved or similar
+      m_trace(4 - verbosity) << "Pull run directory at end of job " << std::endl;
+      m_trace(4 - verbosity) << Shell()("echo local rundir;ls -lta '" + m_project.filename("", "", 0).string() + "'")
+                             << std::endl;
+      m_trace(4 - verbosity) << "remote cache directory: " << m_remote_cache_directory << std::endl;
+      m_trace(4 - verbosity) << (*m_backend_command_server)("echo remote cache;ls -lta '" + m_remote_cache_directory +
+                                                            "' 2>&1")
+                             << std::endl;
+      auto rundir_result = pull_rundir(verbosity);
+      m_trace(4 - verbosity) << Shell()("echo local rundir;ls -lta '" + m_project.filename("", "", 0).string() + "'")
+                             << std::endl;
+      m_trace(4 - verbosity) << (*m_backend_command_server)("echo remote cache;ls -lta '" + m_remote_cache_directory +
+                                                            "'  2>&1")
+                             << std::endl;
+      auto remote_manifest = vector_to_set(util::splitString(
+          (*m_backend_command_server)("ls -1 '" + m_remote_cache_directory + "' 2>&1 | grep -v Info.plist"), '\n'));
+      auto local_manifest = vector_to_set(util::splitString(
+          Shell()("ls -1 '" + m_project.filename("", "", 0).string() + "' 2>&1 | grep -v Info.plist"), '\n'));
+      //    std::cout << "rundir_result " << std::get<0>(rundir_result) << std::endl;
+      if (!std::get<0>(rundir_result) or remote_manifest == local_manifest) {
+        {
+          m_trace(4 - verbosity) << "remove run directory " + m_remote_cache_directory + " at end of job "
+                                 << std::endl;
+          auto slash = m_remote_cache_directory.rfind("/");
+          (*m_backend_command_server)("cd '" + m_remote_cache_directory.substr(0, slash) + "' && rm -rf '" +
+                                      m_remote_cache_directory.substr(slash + 1) + "'");
+        }
+      } else if (remote_manifest.count("No such file") !=
+                 0) { // sometimes sync will be tried before the remote cache
+                     // exists, so stay quiet when that happens
+        m_trace(-verbosity) << "Not removing remote cache " << m_backend.host + ":'" + m_remote_cache_directory + "'"
+                            << " because master local copy " << m_project.filename("", "", 0) << " has failed to update"
+                            << std::endl;
+        m_trace(-verbosity) << "remote manifest:\n" << remote_manifest << std::endl;
+        m_trace(-verbosity) << "local manifest:\n" << local_manifest << std::endl;
+        m_trace(-verbosity) << "Output stream from rsync:\n" << std::get<1>(rundir_result) << std::endl;
+        m_trace(-verbosity) << "Error stream from rsync:\n" << std::get<2>(rundir_result) << std::endl;
+        m_trace(-verbosity) << "To recover manually, try\n"
+                            << "rsync -asv " << m_backend.host + ":'" + m_remote_cache_directory + "/'" << " '"
+                            << m_project.filename("", "", 0).string() + "'" << std::endl;
       }
-    } else if (remote_manifest.count("No such file") != 0) { // sometimes sync will be tried before the remote cache
-                                                             // exists, so stay quiet when that happens
-      m_trace(-verbosity) << "Not removing remote cache " << m_backend.host + ":'" + m_remote_cache_directory + "'"
-                          << " because master local copy " << m_project.filename("", "", 0) << " has failed to update"
-                          << std::endl;
-      m_trace(-verbosity) << "remote manifest:\n" << remote_manifest << std::endl;
-      m_trace(-verbosity) << "local manifest:\n" << local_manifest << std::endl;
-      m_trace(-verbosity) << "Output stream from rsync:\n" << std::get<1>(rundir_result) << std::endl;
-      m_trace(-verbosity) << "Error stream from rsync:\n" << std::get<2>(rundir_result) << std::endl;
-      m_trace(-verbosity) << "To recover manually, try\n"
-                          << "rsync -asv " << m_backend.host + ":'" + m_remote_cache_directory + "/'" << " '"
-                          << m_project.filename("", "", 0).string() + "'" << std::endl;
+    } catch (const std::exception& e) {
+      m_trace(-verbosity) << "End-of-job remote cache cleanup failed, leaving remote cache " << m_backend.host
+                          << ":'" << m_remote_cache_directory << "' in place: " << e.what() << std::endl;
     }
   }
   // Publish the terminal status only now, after all the trailing pull_rundir()/remote-cache

--- a/src/sjef/util/Job.cpp
+++ b/src/sjef/util/Job.cpp
@@ -26,8 +26,6 @@ namespace sjef::util {
 
 ///> @private
 const bool Job::localhost() const { return (m_backend.host.empty() || m_backend.host == "localhost"); }
-
-std::mutex kill_mutex;
 sjef::util::Job::Job(const sjef::Project& project)
     : m_project(project), m_backend(m_project.backends().at(m_project.property_get("backend"))),
       m_remote_cache_directory(m_backend.cache + "/" +
@@ -215,7 +213,7 @@ std::string Job::run(const std::string& command, int verbosity, bool wait) {
   m_backend_command_server.reset(new Shell(m_backend.host));
   std::string run_output;
   {
-    auto l = std::lock_guard(kill_mutex);
+    auto l = std::lock_guard(m_kill_mutex);
     //  const auto& substr = std::regex_replace(command, std::regex{"'"}, "").substr(0, m_backend.run_command.size());
     m_trace(4 - verbosity) << "Job::run() command=" << command << std::endl;
     //  m_trace(4 - verbosity) << "Job::run substr=" << substr << " m_backend.run_command=" << m_backend.run_command
@@ -328,7 +326,7 @@ void Job::kill(int verbosity) {
     }
   }
   {
-    auto l = std::lock_guard(kill_mutex);
+    auto l = std::lock_guard(m_kill_mutex);
     //    std::cout << "Job::kill() gets mutex"<<std::endl;
     if (m_backend_command_server != nullptr) {
       auto status_string = (*m_backend_command_server)(m_backend.kill_command + " " + std::to_string(m_job_number),
@@ -357,7 +355,7 @@ void Job::poll_job(int verbosity) {
   while (true) {
     //    std::cout << "m_killed " << m_killed << std::endl;
     {
-      auto l = std::lock_guard(kill_mutex);
+      auto l = std::lock_guard(m_kill_mutex);
       //      std::cout << "active polling cycle starts"<<std::endl;
       //      if (m_killed)
       //        std::cout << "poll_job received kill sentinel" << std::endl;

--- a/src/sjef/util/Job.cpp
+++ b/src/sjef/util/Job.cpp
@@ -69,6 +69,16 @@ private:
   HostConnectionThrottle& m_throttle;
 };
 
+HostConnectionThrottle& throttle_for_host(const std::string& host, int max_concurrent,
+                                          std::map<std::string, std::unique_ptr<HostConnectionThrottle>>& registry,
+                                          std::mutex& registry_mutex) {
+  std::lock_guard l(registry_mutex);
+  auto [it, inserted] = registry.try_emplace(host, nullptr);
+  if (inserted)
+    it->second = std::make_unique<HostConnectionThrottle>(max_concurrent);
+  return *it->second;
+}
+
 HostConnectionThrottle& handshake_throttle_for_host(const std::string& host) {
   // How many new-session handshakes to a single host may be in flight at once. Deliberately well under
   // OpenSSH's own conservative defaults for simultaneous unauthenticated/new connections (e.g.
@@ -77,11 +87,23 @@ HostConnectionThrottle& handshake_throttle_for_host(const std::string& host) {
   constexpr int max_concurrent_handshakes_per_host = 3;
   static std::mutex registry_mutex;
   static std::map<std::string, std::unique_ptr<HostConnectionThrottle>> registry;
-  std::lock_guard l(registry_mutex);
-  auto [it, inserted] = registry.try_emplace(host, nullptr);
-  if (inserted)
-    it->second = std::make_unique<HostConnectionThrottle>(max_concurrent_handshakes_per_host);
-  return *it->second;
+  return throttle_for_host(host, max_concurrent_handshakes_per_host, registry, registry_mutex);
+}
+
+HostConnectionThrottle& rsync_throttle_for_host(const std::string& host) {
+  // How many rsync invocations (push_rundir/pull_rundir) against a single host may be in flight at
+  // once. Unlike the handshake throttle above, this bounds a genuinely different, and far more
+  // frequently hit, server-side resource: every rsync call's --rsh multiplexes onto the *one* shared
+  // ssh ControlMaster connection per host (see system_specific_ssh_options()), so all of them together
+  // -- across every concurrently-running job for this host, for the job's entire lifetime, not just its
+  // launch -- compete for that one connection's session slots. A real login node was observed refusing
+  // sessions outright ("mux_client_request_session: session request failed: Session open refused by
+  // peer") once enough concurrent jobs' launches and poll cycles overlapped, which is exactly OpenSSH's
+  // own MaxSessions (default 10) being exceeded. This keeps concurrent usage well under that.
+  constexpr int max_concurrent_rsyncs_per_host = 4;
+  static std::mutex registry_mutex;
+  static std::map<std::string, std::unique_ptr<HostConnectionThrottle>> registry;
+  return throttle_for_host(host, max_concurrent_rsyncs_per_host, registry, registry_mutex);
 }
 } // namespace
 
@@ -178,6 +200,7 @@ std::tuple<bool, std::string, std::string> sjef::util::Job::push_rundir(int verb
   m_project.m_trace(2 - verbosity) << "Push rsync: " << command << std::endl;
   auto start_time = std::chrono::steady_clock::now();
   ensure_remote_cache_directory();
+  ThrottleGuard rsync_throttle(rsync_throttle_for_host(m_backend.host));
   const Shell& shell = Shell("localhost", "");
   std::string rsync_out;
   try {
@@ -231,6 +254,7 @@ std::tuple<bool, std::string, std::string> sjef::util::Job::pull_rundir(int verb
     command += " -v";
   m_project.m_trace(2 - verbosity) << "Pull rsync: " << command << std::endl;
   auto start_time = std::chrono::steady_clock::now();
+  ThrottleGuard rsync_throttle(rsync_throttle_for_host(m_backend.host));
   const Shell& shell = Shell("localhost", "");
   std::string rsync_out;
   try {

--- a/src/sjef/util/Job.cpp
+++ b/src/sjef/util/Job.cpp
@@ -399,7 +399,18 @@ void Job::poll_job(int verbosity) {
       }
       m_trace(4 - verbosity) << "got status " << status << std::endl;
       pull_rundir(verbosity);
-      set_status(status);
+      // Don't publish a terminal status (completed/killed) for a remote job yet: the block below
+      // this loop still has to pull the run directory one or more times more, compare manifests
+      // against the remote cache, and remove that remote cache -- all further I/O against this
+      // same local project directory. Publishing "completed" here lets an external caller (e.g.
+      // pysjef's Project.wait(), which only loops on "running"/"waiting") see the job as finished
+      // and start touching or deleting the local project directory while that trailing I/O is
+      // still in flight, racing a pull_rundir() rsync against a directory being removed out from
+      // under it. Local jobs have no such follow-up I/O (see the localhost() guard below), so
+      // publishing immediately for them is safe and keeps existing behaviour.
+      bool about_to_finish = (status == completed or status == killed or m_killed) and !localhost();
+      if (!about_to_finish)
+        set_status(status);
       //    std::cout << "set status " << m_project.status_message() << std::endl;
       stop = Clock::now();
       {
@@ -467,6 +478,12 @@ void Job::poll_job(int verbosity) {
                           << m_project.filename("", "", 0).string() + "'" << std::endl;
     }
   }
+  // Publish the terminal status only now, after all the trailing pull_rundir()/remote-cache
+  // cleanup above has actually finished touching the local project directory (see the deferral
+  // at the top of the loop). status_from_output() re-derives from status() by default, so this
+  // still applies its own override (downgrading to "failed" if the pulled output records an
+  // error) exactly as before -- only the timing of the first, terminal set_status() moved.
+  set_status(status);
   m_project.m_xml_cached = "";
   set_status(m_project.status_from_output());
   m_backend_command_server.reset(); // close down backend server as no longer needed

--- a/src/sjef/util/Job.cpp
+++ b/src/sjef/util/Job.cpp
@@ -2,9 +2,13 @@
 #include "Shell.h"
 #include "util.h"
 #include <chrono>
+#include <condition_variable>
 #include <fstream>
 #include <functional>
 #include <future>
+#include <map>
+#include <memory>
+#include <mutex>
 #include <regex>
 #include <set>
 #include <signal.h>
@@ -24,6 +28,63 @@ namespace fs = std::filesystem;
 
 namespace sjef::util {
 
+namespace {
+// Bounds how many Job constructors may simultaneously be inside the "new session handshake" (which
+// rsync / rsync --version / remote cache setup, over a freshly-spawned ssh session) for the same
+// remote host. Launching many jobs in parallel against a real remote login node was observed to spawn
+// that many brand-new ssh sessions at once, each immediately sending its handshake commands -- and a
+// burst like that can make even a login node that is perfectly healthy for one connection at a time
+// become unresponsive (well within OpenSSH's own default connection-flood defenses, e.g. MaxStartups),
+// producing exactly the "no response" timeouts this throttle exists to avoid triggering in the first
+// place. It only gates the handshake, not the job's subsequent run/poll lifecycle, so once a session is
+// past this, it proceeds fully independently and concurrently with every other job as before.
+class HostConnectionThrottle {
+public:
+  explicit HostConnectionThrottle(int max_concurrent) : m_max(max_concurrent) {}
+  void acquire() {
+    std::unique_lock l(m_mutex);
+    m_cv.wait(l, [&] { return m_count < m_max; });
+    ++m_count;
+  }
+  void release() {
+    std::lock_guard l(m_mutex);
+    --m_count;
+    m_cv.notify_one();
+  }
+
+private:
+  std::mutex m_mutex;
+  std::condition_variable m_cv;
+  int m_count = 0;
+  const int m_max;
+};
+
+class ThrottleGuard {
+public:
+  explicit ThrottleGuard(HostConnectionThrottle& throttle) : m_throttle(throttle) { m_throttle.acquire(); }
+  ~ThrottleGuard() { m_throttle.release(); }
+  ThrottleGuard(const ThrottleGuard&) = delete;
+
+private:
+  HostConnectionThrottle& m_throttle;
+};
+
+HostConnectionThrottle& handshake_throttle_for_host(const std::string& host) {
+  // How many new-session handshakes to a single host may be in flight at once. Deliberately well under
+  // OpenSSH's own conservative defaults for simultaneous unauthenticated/new connections (e.g.
+  // MaxStartups 10:30:100), so this throttle -- not the remote sshd's own flood defenses -- is what
+  // determines how launches against a busy or fragile login node are paced.
+  constexpr int max_concurrent_handshakes_per_host = 3;
+  static std::mutex registry_mutex;
+  static std::map<std::string, std::unique_ptr<HostConnectionThrottle>> registry;
+  std::lock_guard l(registry_mutex);
+  auto [it, inserted] = registry.try_emplace(host, nullptr);
+  if (inserted)
+    it->second = std::make_unique<HostConnectionThrottle>(max_concurrent_handshakes_per_host);
+  return *it->second;
+}
+} // namespace
+
 ///> @private
 const bool Job::localhost() const { return (m_backend.host.empty() || m_backend.host == "localhost"); }
 sjef::util::Job::Job(const sjef::Project& project)
@@ -35,6 +96,7 @@ sjef::util::Job::Job(const sjef::Project& project)
       m_initial_status(static_cast<sjef::status>(std::stoi("0" + m_project.property_get("_status")))) {
   //  std::cout << "Job constructor, m_job_number=" << m_job_number << std::endl;
   if (!localhost()) {
+    ThrottleGuard throttle(handshake_throttle_for_host(m_backend.host));
     m_remote_rsync =
         (*m_backend_command_server)("PATH=$HOME/bin:/usr/local/bin:/opt/homebrew/bin:/opt/bin:$PATH which rsync");
     if (m_remote_rsync.empty())

--- a/src/sjef/util/Job.cpp
+++ b/src/sjef/util/Job.cpp
@@ -529,7 +529,14 @@ void Job::poll_job(int verbosity) {
       m_trace(4 - verbosity) << "active polling cycle stops" << std::endl;
     }
     using namespace std::literals::chrono_literals;
-    std::this_thread::sleep_for(10ms);
+    // For a remote backend, each cycle above is a real network round trip (a status check plus an
+    // rsync pull), and a Molpro calculation's state does not change on a sub-second timescale, so
+    // polling much faster than that is pure overhead -- and doing so concurrently across many jobs at
+    // once (e.g. right after a large batch is launched, before this cycle's own backoff below has had
+    // a chance to grow from a fast initial cycle) is exactly what was observed overloading a real
+    // login node into refusing new sessions and going unresponsive. Local jobs have no such cost, so
+    // keep their much tighter floor.
+    std::this_thread::sleep_for(localhost() ? 10ms : 500ms);
     std::this_thread::sleep_for((stop - start) * 2);
   }
   // Only perform the remote-cache cleanup (which can delete the remote run directory) when we have

--- a/src/sjef/util/Job.h
+++ b/src/sjef/util/Job.h
@@ -63,6 +63,14 @@ protected:
   bool m_killed = false;
   bool m_closing = false; //!< set to signal that polling should be stopped
   std::mutex m_closing_mutex;
+  //! Guards this job's own m_backend_command_server/m_job_number/m_killed against a concurrent
+  //! kill() racing run()'s (re)creation of the backend server, and against poll_job()'s status
+  //! reads racing kill()'s status write. Deliberately a member, not a process-wide global: this
+  //! job's launch/poll/kill must never serialize against an unrelated Job's, since each Job's
+  //! push/submit/pull is itself blocking network I/O that can take seconds against a real remote
+  //! host, and a shared lock would turn concurrent parallel launches into a queue where one slow
+  //! or stuck remote call freezes every other job's launch and status polling too.
+  std::mutex m_kill_mutex;
   status m_initial_status;
   //! Set once get_status() has genuinely (not by default/fallback) observed this job as running or
   //! waiting. Used to distinguish a trustworthy "it was running and has now disappeared, so it must

--- a/src/sjef/util/Shell.cpp
+++ b/src/sjef/util/Shell.cpp
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <filesystem>
+#include <iostream>
 #include <mutex>
 #include <regex>
 #include <sstream>
@@ -63,6 +64,23 @@ Shell::Shell(std::string host, std::string shell) : m_host(std::move(host)), m_s
     //    std::cout << "ssh is"<<ssh<<", "<<m_process.valid()<<", "<<m_process.running()<<std::endl;
     if (!m_process.valid() || !m_process.running())
       throw Shell::runtime_error("Spawning run process has failed");
+  }
+}
+
+Shell::~Shell() {
+  // valid() is false for a process that was never started (e.g. localhost()), already reaped by
+  // wait()/exit_code(), or explicitly detach()ed by run_local_async() for a fire-and-forget local job
+  // -- detach() means "this process should keep running independently of this Shell object", so this
+  // must not touch it. Anything still valid() and running() here is a live session (interactive remote
+  // shell, or a synchronous local/rsync child between spawning and this destructor somehow being
+  // reached first) that nothing else is ever going to wait for or use again; terminate it rather than
+  // leaving it to run forever as an orphan.
+  try {
+    if (m_process.valid() && m_process.running())
+      m_process.terminate();
+  } catch (...) {
+    // Best-effort cleanup only; a destructor must not throw, and there is nothing more useful to do
+    // with a failure to terminate an already-orphaned process.
   }
 }
 

--- a/src/sjef/util/Shell.cpp
+++ b/src/sjef/util/Shell.cpp
@@ -201,16 +201,27 @@ void Shell::run_local_sync(const std::string& command, const std::string& direct
   }
   if (!m_process.valid())
     throw Shell::runtime_error("Spawning run process has failed");
-  std::string line;
   try {
-    while (std::getline(*m_err, line) && line.substr(0, terminator.size()) != terminator) {
-      m_last_err += line + '\n';
-    }
+    read_lines_with_deadline(
+        m_err,
+        [&](const std::string& l) {
+          if (l.substr(0, terminator.size()) == terminator)
+            return true;
+          m_last_err += l + '\n';
+          return false;
+        },
+        "local command stderr (\"" + command + "\")", command_idle_timeout);
     // std::cout << "wait , read output" << std::endl;
-    while (std::getline(*m_out, line) && line != terminator) {
-      // std::cout << "out line from command " << line << std::endl;
-      m_last_out += line + '\n';
-    }
+    read_lines_with_deadline(
+        m_out,
+        [&](const std::string& l) {
+          if (l == terminator)
+            return true;
+          m_last_out += l + '\n';
+          // std::cout << "out line from command " << l << std::endl;
+          return false;
+        },
+        "local command output (\"" + command + "\")", command_idle_timeout);
     m_job_number = 0;
     // std::cout << "finished wait , read output" << std::endl;
     // std::cout << "m_last_output " << m_last_out << std::endl;

--- a/src/sjef/util/Shell.cpp
+++ b/src/sjef/util/Shell.cpp
@@ -11,7 +11,9 @@
 #endif
 #endif
 #include <chrono>
+#include <condition_variable>
 #include <filesystem>
+#include <mutex>
 #include <regex>
 #include <sstream>
 #include <thread>
@@ -36,6 +38,13 @@ namespace sjef::util {
 static std::string executable(const std::string& command);
 const std::string jobnumber_tag{"@@@JOBNUMBER"};
 const std::string terminator{"@@@EOF"};
+// How long to wait for the next line of output from a command's stream before concluding that the
+// process on the other end (in practice, almost always a remote login node/session over ssh) has gone
+// unresponsive. Deliberately generous rather than tight, like rsync's own --timeout=5 elsewhere in this
+// codebase: unlike that idle timeout on an already-flowing data transfer, this covers the first response
+// to a freshly-sent command, which can legitimately take a while on a loaded shared login node (PAM,
+// profile scripts, etc.), and a false positive here misreports a slow-but-healthy job as unresponsive.
+constexpr auto command_idle_timeout = std::chrono::seconds(30);
 
 Shell::Shell(std::string host, std::string shell) : m_host(std::move(host)), m_shell((shell)) {
   // std::cout << "Shell() host=" << m_host << ", local? " << localhost() << ", shell=" << m_shell << std::endl;
@@ -224,18 +233,18 @@ void Shell::run_local_sync(const std::string& command, const std::string& direct
 void Shell::capture_job_number_from_error(const std::string& command) const {
   m_last_err.clear();
   m_job_number = 0;
-  std::string line;
   try {
-    while (std::getline(*m_err, line)) {
-      // std::cout << "capture_job_number_from_error, line=" << line << std::endl;
-      std::smatch match;
-      if (std::regex_search(line, match, std::regex{jobnumber_tag + "\\s*(\\d+)"})) {
-        // std::cout << "capture_job_number_from_error, match=" << match[1] << std::endl;
-        m_job_number = std::stoi(match[1]);
-        // std::cout << "stoi survives, capture_job_number_from_error, match=" << m_job_number << std::endl;
-        break;
-      }
-    }
+    read_lines_with_deadline(
+        m_err,
+        [&](const std::string& line) {
+          std::smatch match;
+          if (std::regex_search(line, match, std::regex{jobnumber_tag + "\\s*(\\d+)"})) {
+            m_job_number = std::stoi(match[1]);
+            return true;
+          }
+          return false;
+        },
+        "job-number echo from \"" + command + "\"", command_idle_timeout);
   } catch (const std::exception& e) {
     throw runtime_error(
         (std::string{"Shell(\""} + command + "\") has failed whilst capturing the job number.\nExit code: " +
@@ -329,15 +338,84 @@ void Shell::run_remote_sync(std::string command, const std::string& directory, i
     throw Shell::runtime_error("remote server process has died");
 }
 
+void Shell::read_lines_with_deadline(const std::shared_ptr<std::istream>& stream,
+                                     const std::function<bool(const std::string&)>& on_line,
+                                     const std::string& context, std::chrono::seconds idle_timeout) const {
+  struct SharedState {
+    std::mutex mutex;
+    std::condition_variable cv;
+    std::string line;
+    bool line_ready = false;
+    bool finished = false; // set once the reader has hit eof or an error; `error` distinguishes which
+    std::exception_ptr error;
+  };
+  auto state = std::make_shared<SharedState>();
+  // This reader keeps blocking on std::getline() against `stream` for as long as the process feeding it
+  // stays silent -- there is no way to cancel a blocking read on a pipe, so if the wait below times out,
+  // this thread is abandoned still trying to read rather than joined. It only touches `state` and
+  // `stream`, both captured by shared_ptr, so it stays safe to run to completion (or forever) regardless
+  // of whether this Shell, or even this call to read_lines_with_deadline, still exists by then.
+  std::thread([state, stream]() {
+    std::string next_line;
+    try {
+      while (std::getline(*stream, next_line)) {
+        std::unique_lock l(state->mutex);
+        state->line = next_line;
+        state->line_ready = true;
+        state->cv.notify_one();
+        // Wait for the consumer to take this line before reading the next one, so that a slow
+        // consumer (blocked on its own deadline logic) can't cause lines to be read and lost before
+        // anyone looks at them.
+        state->cv.wait(l, [&] { return !state->line_ready; });
+      }
+    } catch (...) {
+      std::lock_guard l(state->mutex);
+      state->error = std::current_exception();
+      state->finished = true;
+      state->cv.notify_one();
+      return;
+    }
+    std::lock_guard l(state->mutex);
+    state->finished = true;
+    state->cv.notify_one();
+  }).detach();
+
+  while (true) {
+    std::unique_lock l(state->mutex);
+    if (!state->cv.wait_for(l, idle_timeout, [&] { return state->line_ready || state->finished; }))
+      throw Shell::runtime_error((std::string{"No response (for "} + std::to_string(idle_timeout.count()) +
+                                  "s) whilst waiting for " + context +
+                                  " -- the remote host or session appears unresponsive")
+                                     .c_str());
+    if (state->line_ready) {
+      auto received = std::move(state->line);
+      state->line_ready = false;
+      l.unlock();
+      state->cv.notify_one(); // let the reader proceed to the next line
+      if (on_line(received))
+        return;
+      continue;
+    }
+    // finished: either eof (no error) or a genuine stream error
+    if (state->error)
+      std::rethrow_exception(state->error);
+    return;
+  }
+}
+
 void Shell::capture_out() const {
   // std::cout << "capture_out" << m_last_out << std::endl;
   m_last_out.clear();
-  std::string line;
   try {
-    while (std::getline(*m_out, line) && line != terminator) {
-      // std::cout << "capture_out, line=" << line << std::endl;
-      m_last_out += line + '\n';
-    }
+    read_lines_with_deadline(
+        m_out,
+        [&](const std::string& line) {
+          if (line == terminator)
+            return true;
+          m_last_out += line + '\n';
+          return false;
+        },
+        "command output" + (localhost() ? std::string{} : " from " + m_host), command_idle_timeout);
   } catch (const std::exception& e) {
     throw Shell::runtime_error((std::string{"Shell() has failed whilst capturing the output.\nExit code: "} +
                                 std::to_string(m_process.exit_code()) + "\n\nstdout:\n" + m_last_out +

--- a/src/sjef/util/Shell.cpp
+++ b/src/sjef/util/Shell.cpp
@@ -347,6 +347,13 @@ void Shell::read_lines_with_deadline(const std::shared_ptr<std::istream>& stream
     std::string line;
     bool line_ready = false;
     bool finished = false; // set once the reader has hit eof or an error; `error` distinguishes which
+    // Set once the consumer is done, whether because on_line() said so or because it gave up on a
+    // timeout. Tells the reader not to start (or report the result of) another blocking read: without
+    // this, a reader left over from one call -- e.g. one line "ahead", already unblocked and back in
+    // getline() for what it assumes is still this call's stream -- races the *next* call's own new
+    // reader thread for whatever the process sends next, on the same shared stream, and can steal or
+    // corrupt that next call's response instead of it ever reaching its own reader.
+    bool stop_requested = false;
     std::exception_ptr error;
   };
   auto state = std::make_shared<SharedState>();
@@ -354,45 +361,68 @@ void Shell::read_lines_with_deadline(const std::shared_ptr<std::istream>& stream
   // stays silent -- there is no way to cancel a blocking read on a pipe, so if the wait below times out,
   // this thread is abandoned still trying to read rather than joined. It only touches `state` and
   // `stream`, both captured by shared_ptr, so it stays safe to run to completion (or forever) regardless
-  // of whether this Shell, or even this call to read_lines_with_deadline, still exists by then.
+  // of whether this Shell, or even this call to read_lines_with_deadline, still exists by then. Once it
+  // does eventually unblock, stop_requested tells it to quietly exit instead of publishing a result
+  // nobody is listening for (see SharedState::stop_requested above).
   std::thread([state, stream]() {
     std::string next_line;
     try {
       while (std::getline(*stream, next_line)) {
         std::unique_lock l(state->mutex);
+        if (state->stop_requested)
+          return;
         state->line = next_line;
         state->line_ready = true;
         state->cv.notify_one();
-        // Wait for the consumer to take this line before reading the next one, so that a slow
-        // consumer (blocked on its own deadline logic) can't cause lines to be read and lost before
-        // anyone looks at them.
+        // Wait for the consumer to fully decide what to do with this line -- not just acknowledge
+        // receiving it -- before reading the next one. The consumer clears line_ready and sets
+        // stop_requested (if it's done) atomically under this same lock before releasing us, so by
+        // the time we wake up here we already know whether to loop for another line or stop; there
+        // is no window where we could race ahead into another blocking read the consumer never asked
+        // for.
         state->cv.wait(l, [&] { return !state->line_ready; });
+        if (state->stop_requested)
+          return;
       }
     } catch (...) {
       std::lock_guard l(state->mutex);
+      if (state->stop_requested)
+        return;
       state->error = std::current_exception();
       state->finished = true;
       state->cv.notify_one();
       return;
     }
     std::lock_guard l(state->mutex);
+    if (state->stop_requested)
+      return;
     state->finished = true;
     state->cv.notify_one();
   }).detach();
 
   while (true) {
     std::unique_lock l(state->mutex);
-    if (!state->cv.wait_for(l, idle_timeout, [&] { return state->line_ready || state->finished; }))
+    if (!state->cv.wait_for(l, idle_timeout, [&] { return state->line_ready || state->finished; })) {
+      // Whenever the reader does eventually unblock (which may be never), tell it to give up quietly
+      // rather than hand a now-irrelevant line to nobody and potentially collide with whatever fresh
+      // read the next call on this stream starts in the meantime.
+      state->stop_requested = true;
       throw Shell::runtime_error((std::string{"No response (for "} + std::to_string(idle_timeout.count()) +
                                   "s) whilst waiting for " + context +
                                   " -- the remote host or session appears unresponsive")
                                      .c_str());
+    }
     if (state->line_ready) {
       auto received = std::move(state->line);
       state->line_ready = false;
+      // Decide before releasing the reader: it must already know whether to stop by the time
+      // line_ready flips, not find out only after it has started blocking on another read.
+      bool stop = on_line(received);
+      if (stop)
+        state->stop_requested = true;
       l.unlock();
-      state->cv.notify_one(); // let the reader proceed to the next line
-      if (on_line(received))
+      state->cv.notify_one();
+      if (stop)
         return;
       continue;
     }

--- a/src/sjef/util/Shell.h
+++ b/src/sjef/util/Shell.h
@@ -37,6 +37,15 @@ public:
   Shell(std::string host, std::string shell = "/bin/bash");
   Shell() : Shell("localhost") {}
   /*!
+   * @brief Terminate this Shell's underlying process if it's still running and wasn't explicitly
+   * detached (e.g. by run_local_async() for a fire-and-forget local job). Without this, replacing a
+   * Shell that still has a live interactive session -- e.g. every Job::run() call's
+   * `m_backend_command_server.reset(new Shell(...))`, including every retry of a failed launch --
+   * orphans the old ssh process instead of ending it, leaking one persistent remote session per
+   * replacement for as long as the machine stays up.
+   */
+  ~Shell();
+  /*!
    *@brief Execute a command. For a remote host, the command is sent to the remote shell already set up in the class
    * constructor. For a local host, a new process is created.
    *

--- a/src/sjef/util/Shell.h
+++ b/src/sjef/util/Shell.h
@@ -3,6 +3,9 @@
 #define BOOST_ALL_NO_LIB
 #define BOOST_PROCESS_USE_STD_FS
 #include "Logger.h"
+#include <chrono>
+#include <functional>
+#include <memory>
 #if __has_include(<boost/process/child.hpp>)
 #include <boost/process/child.hpp>
 #include <boost/process/io.hpp>
@@ -78,8 +81,11 @@ private:
   const std::string m_host;
   const std::string m_shell;
   mutable bp::opstream m_in;
-  mutable std::unique_ptr<bp::ipstream> m_out;
-  mutable std::unique_ptr<bp::ipstream> m_err;
+  // shared_ptr, not unique_ptr: read_lines_with_deadline() may abandon a reader thread that is still
+  // blocked on one of these streams (see its doc comment), and that thread needs the stream to stay
+  // alive for as long as it might still touch it, independent of this Shell's own lifetime.
+  mutable std::shared_ptr<bp::ipstream> m_out;
+  mutable std::shared_ptr<bp::ipstream> m_err;
   mutable std::string m_last_out;
   mutable std::string m_last_err;
   mutable Logger m_trace;
@@ -99,6 +105,22 @@ protected:
   void run_remote_sync(std::string command, const std::string& directory, int verbosity, const std::string& out) const;
   void capture_out() const;
   bool localhost() const { return (m_host.empty() || m_host == "localhost"); }
+  /*!
+   * @brief Read lines from stream, invoking on_line(line) for each, until on_line returns true or EOF.
+   *
+   * Bounds the wait for each individual line to idle_timeout: if the process feeding stream (e.g. an
+   * unresponsive remote login node/session, or a stuck local command) goes silent for longer than that
+   * with no line and no EOF, throws Shell::runtime_error naming context, instead of blocking forever.
+   *
+   * The underlying std::getline() this drives has no way to be interrupted once it has started
+   * blocking, so on timeout the reader thread is deliberately abandoned (detached) rather than joined;
+   * stream is kept alive independently (via shared_ptr) for as long as that abandoned thread needs it.
+   * Callers must treat a timeout as this Shell being unusable and construct a fresh one -- which is
+   * already how Job.cpp recovers from any Shell::runtime_error out of this class.
+   */
+  void read_lines_with_deadline(const std::shared_ptr<std::istream>& stream,
+                                const std::function<bool(const std::string&)>& on_line, const std::string& context,
+                                std::chrono::seconds idle_timeout) const;
 };
 
 std::vector<std::string> tokenise(const std::string& command);


### PR DESCRIPTION
## Summary

A series of fixes improving reliability of remote (ssh-backed) job submission and monitoring, found while debugging intermittent failures and hangs when launching many jobs in parallel (`Database.run(parallel=...)` in pymolpro) against real remote login nodes.

- **`kill_mutex` made per-job, not a process-wide global** — it was serializing every concurrent job's launch/poll cycle against every other job in the process, turning intended parallelism into a queue where one slow remote call froze everyone.
- **Terminal status publish deferred until end-of-job cleanup finishes** — publishing "completed" before the trailing `pull_rundir()`/remote-cache cleanup let an external caller (e.g. `Project.wait()`) start touching the local project directory while that cleanup was still syncing into it, causing an intermittent `mkdir ... No such file or directory` rsync failure.
- **Bounded, timeout-based reads added throughout `Shell`** (`capture_out()`, `capture_job_number_from_error()`, and the local rsync subprocess reads in `run_local_sync()`) — these previously blocked forever with no timeout if a remote session/login node stopped responding. A background-thread-based reader with a 30s idle deadline was added, including a fix for a reader-thread leak found while testing it (a leftover reader from one call could race a later call's own reader for the same stream).
- **New-session handshakes throttled per host** (max 3 concurrent) — launching many jobs in parallel was observed spawning that many brand-new ssh sessions at once, which can overwhelm a login node on its own.
- **`push_rundir()`/`pull_rundir()` rsync invocations throttled per host** (max 4 concurrent) — these multiplex over the *one* shared ssh ControlMaster connection per host; enough concurrent jobs (each polling continuously, not just at launch) exceeded the remote sshd's `MaxSessions`, causing `mux_client_request_session: session request failed: Session open refused by peer`.
- **`Shell` now has a destructor that terminates its underlying process if still running** — it previously had none, so replacing a live `Shell` (which happens on every job launch, including every retry) orphaned the old ssh session instead of ending it. This was leaking persistent sessions under retry-heavy workloads.
- **`poll_job()` no longer dies silently on a failed `pull_rundir()`** — none of its three call sites, nor the end-of-job cleanup block, were guarded against exceptions. Since `poll_job()` runs on a `std::async` thread nothing ever calls `.get()` on, an uncaught exception there terminated polling silently, leaving status stuck (typically at "running"/"waiting") and every external caller hanging forever with no error — while the job may have genuinely already finished on the remote.
- **Remote jobs poll no faster than every 500ms** (was a flat 10ms floor for all backends) — each cycle is a real network round trip: a status check plus an rsync pull. Local jobs are unaffected.

## Testing

Extensively tested live against two real remote hosts (through the pymolpro test harness, not included in this PR) under parallel loads of 5-16 simultaneous jobs, including reproducing and then confirming resolution of the specific `Session open refused by peer` and reader-thread-leak failures. Also confirmed via live `lldb` thread-dump inspection during a hang, and via process monitoring that no ssh sessions are leaked across many retries.

One further mitigation (throttling how many jobs may be simultaneously *alive*, not just launching, against a host) was attempted, found to deadlock, and deliberately **not** included here — see conversation history if picking this up again.

Independent of any code fix: a standalone (sjef-free) `ssh` concurrency probe script confirmed that at least one of the test hosts sometimes fails to respond even to a single, unconcurrent connection attempt ("Connection timed out during banner exchange"), pointing at a genuine server-side/sshd issue on that host rather than anything client-side. That's been passed to the relevant sysadmins separately.