### PR TITLE
Fix synchronous batch job submission for local and ssh-loopback backends

### DIFF
--- a/src/sjef/util/Shell.cpp
+++ b/src/sjef/util/Shell.cpp
@@ -190,6 +190,12 @@ void Shell::run_local_sync(const std::string& command, const std::string& direct
   }
   fs::current_path(directory);
 
+  // Whether the child's stdout/stderr are wired up to m_out/m_err (to be read back below) or redirected
+  // straight to the caller-supplied files. Only in the former case is there anything for this function to
+  // read afterwards -- reading m_out/m_err in the latter case would wait on pipes the child was never
+  // connected to, which never produce a line and never hit eof, so it would just block until
+  // read_lines_with_deadline's timeout and then report a spurious "unresponsive" failure.
+  const bool capture_via_pipe = out == "/dev/null" and err == "/dev/null";
   m_out.reset(new bp::ipstream);
   m_err.reset(new bp::ipstream);
   if (m_shell.empty()) {
@@ -197,7 +203,7 @@ void Shell::run_local_sync(const std::string& command, const std::string& direct
     auto tokens = tokenise(command);
     if (!tokens.empty())
       tokens[0] = executable(tokens[0]);
-    if (out == "/dev/null" and err == "/dev/null")
+    if (capture_via_pipe)
       m_process = bp::child(tokens, bp::std_out > *m_out, bp::std_err > *m_err SJEF_NO_CONSOLE_WINDOW);
     else
       m_process = bp::child(tokens, bp::std_out > out, bp::std_err > err SJEF_NO_CONSOLE_WINDOW);
@@ -212,43 +218,45 @@ void Shell::run_local_sync(const std::string& command, const std::string& direct
     // std::cout << "run_local_sync pipeline=" << pipeline << std::endl;
     // std::cout << "run_local_sync out=" << out << std::endl;
     // std::cout << "run_local_sync err=" << err << std::endl;
-    if (out == "/dev/null" and err == "/dev/null")
+    if (capture_via_pipe)
       m_process = bp::child(executable("nohup"), shell_path, "-c", pipeline, bp::std_out > *m_out, bp::std_err > *m_err SJEF_NO_CONSOLE_WINDOW);
     else
       m_process = bp::child(executable("nohup"), shell_path, "-c", pipeline, bp::std_out > out, bp::std_err > err SJEF_NO_CONSOLE_WINDOW);
   }
   if (!m_process.valid())
     throw Shell::runtime_error("Spawning run process has failed");
-  try {
-    read_lines_with_deadline(
-        m_err,
-        [&](const std::string& l) {
-          if (l.substr(0, terminator.size()) == terminator)
-            return true;
-          m_last_err += l + '\n';
-          return false;
-        },
-        "local command stderr (\"" + command + "\")", command_idle_timeout);
-    // std::cout << "wait , read output" << std::endl;
-    read_lines_with_deadline(
-        m_out,
-        [&](const std::string& l) {
-          if (l == terminator)
-            return true;
-          m_last_out += l + '\n';
-          // std::cout << "out line from command " << l << std::endl;
-          return false;
-        },
-        "local command output (\"" + command + "\")", command_idle_timeout);
-    m_job_number = 0;
-    // std::cout << "finished wait , read output" << std::endl;
-    // std::cout << "m_last_output " << m_last_out << std::endl;
-  } catch (const std::exception& e) {
-    throw runtime_error(
-        (std::string{"Shell(\""} + command +
-         "\") has failed whilst capturing the output.\nExit code: " + std::to_string(m_process.exit_code()) +
-         "\n\nstdout:\n" + m_last_out + "\nstderr:\n" + m_last_err + "\nException thrown:" + e.what())
-            .c_str());
+  if (capture_via_pipe) {
+    try {
+      read_lines_with_deadline(
+          m_err,
+          [&](const std::string& l) {
+            if (l.substr(0, terminator.size()) == terminator)
+              return true;
+            m_last_err += l + '\n';
+            return false;
+          },
+          "local command stderr (\"" + command + "\")", command_idle_timeout);
+      // std::cout << "wait , read output" << std::endl;
+      read_lines_with_deadline(
+          m_out,
+          [&](const std::string& l) {
+            if (l == terminator)
+              return true;
+            m_last_out += l + '\n';
+            // std::cout << "out line from command " << l << std::endl;
+            return false;
+          },
+          "local command output (\"" + command + "\")", command_idle_timeout);
+      m_job_number = 0;
+      // std::cout << "finished wait , read output" << std::endl;
+      // std::cout << "m_last_output " << m_last_out << std::endl;
+    } catch (const std::exception& e) {
+      throw runtime_error(
+          (std::string{"Shell(\""} + command +
+           "\") has failed whilst capturing the output.\nExit code: " + std::to_string(m_process.exit_code()) +
+           "\n\nstdout:\n" + m_last_out + "\nstderr:\n" + m_last_err + "\nException thrown:" + e.what())
+              .c_str());
+    }
   }
   fs::current_path(current_path_save);
   m_process.wait();
@@ -356,10 +364,15 @@ void Shell::run_remote_sync(std::string command, const std::string& directory, i
     throw Shell::runtime_error("remote server process has died");
   try {
     m_in << command << std::endl;
-    if (out == "/dev/null") {
-      m_in << "echo '" << terminator << "'" << std::endl;
-      capture_out();
-    }
+    // Always wait for the command to finish, whether or not its own stdout/stderr were redirected to
+    // files: the terminator is a separate, unredirected "echo" sequenced after it on the same
+    // persistent shell session, so it only reaches m_out once the command itself has completed. Without
+    // this, run_remote_sync() would return as soon as the command line was merely handed to the shell's
+    // stdin -- not once it had actually run -- racing every caller that relies on "sync" meaning the
+    // command (and whatever it wrote to `out`) is actually finished, e.g. Job::run()'s pull_rundir() and
+    // run_jobnumber capture immediately afterwards.
+    m_in << "echo '" << terminator << "'" << std::endl;
+    capture_out();
   } catch (const std::exception& e) {
     throw Shell::runtime_error((std::string{"Spawning run process has failed: "} + e.what()).c_str());
   }

--- a/test/test-sjef.cpp
+++ b/test/test-sjef.cpp
@@ -2,11 +2,13 @@
 #include <gtest/gtest.h>
 
 #include "test-sjef.h"
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <list>
 #include <map>
 #include <regex>
+#include <thread>
 #include <sjef/sjef-backend.h>
 #include <sjef/sjef.h>
 #include <sjef/util/Locker.h>
@@ -926,4 +928,102 @@ TEST_F(test_sjef, bad_remote) {
   }
   EXPECT_TRUE(caught);
 #endif
+}
+
+// Exercises a backend that submits to, and polls the status of, an external batch scheduler -- the shape
+// of a real cluster backend (Slurm's sbatch/squeue, or a local queueing tool like task-spool's ts) as
+// opposed to the library's built-in default of directly launching and then tracking a package executable
+// by its own local process id. That default is selected whenever a backend's run_jobnumber field is left
+// exactly equal to the library's own hard-coded sentinel "([0-9]+)", even if a custom regex would
+// happen to match the same text; a batch backend must therefore use some other, textually distinct
+// regex to get the submission-and-polling code path exercised here at all. The scheduler itself is
+// faked with three tiny, dependency-free shell scripts (no real batch system, no chemistry package)
+// backed by a shared "queue" directory of one start-timestamp file per submitted job, so job status is
+// computed from elapsed wall-clock time rather than from a backgrounded process that could be reaped
+// early -- keeping the fake immune to the very races this test exists to catch in the library code.
+TEST_F(test_sjef, scripted_batch_backend) {
+  if (!sjef::util::Shell::local_asynchronous_supported())
+    return;
+  auto suffix = this->suffix();
+  auto backenddirectory = sjef::expand_path((m_dot_sjef / suffix).string());
+  fs::create_directories(backenddirectory);
+  auto queuedirectory = sjef::expand_path((fs::path{backenddirectory} / "queue").string());
+  fs::create_directories(queuedirectory);
+
+  // date(1) truncates to whole seconds, so the fake job's measured elapsed time can be up to 1s shorter
+  // than its real elapsed time (started just before a second boundary, checked just after). Keep the
+  // sampling window (below) comfortably clear of that slop on both ends.
+  constexpr int job_duration_seconds = 5;
+
+  auto write_script = [](const fs::path& path, const std::string& content) {
+    std::ofstream(path) << content;
+    std::system((std::string{"chmod +x '"} + path.string() + "'").c_str());
+  };
+
+  auto submit_script = backenddirectory / "submit.sh";
+  write_script(submit_script, "#!/bin/sh\n"
+                              "dir='" +
+                                  queuedirectory.string() + "'\n"
+                                                    "id=$(( $(cat \"$dir/counter\" 2>/dev/null || echo 0) + 1 ))\n"
+                                                    "echo \"$id\" > \"$dir/counter\"\n"
+                                                    "date +%s > \"$dir/$id.start\"\n"
+                                                    "echo \"Job $id submitted\"\n");
+  auto status_script = backenddirectory / "status.sh";
+  write_script(status_script, "#!/bin/sh\n"
+                              "dir='" +
+                                  queuedirectory.string() + "'\n"
+                                                    "id=\"$1\"\n"
+                                                    "start=$(cat \"$dir/$id.start\" 2>/dev/null || echo 0)\n"
+                                                    "elapsed=$(( $(date +%s) - start ))\n"
+                                                    "if [ -f \"$dir/$id.killed\" ]; then echo \"$id killed\"\n"
+                                                    "elif [ \"$elapsed\" -lt " +
+                                  std::to_string(job_duration_seconds) +
+                                  " ]; then echo \"$id running\"\n"
+                                  "else echo \"$id finished\"\n"
+                                  "fi\n");
+  auto kill_script = backenddirectory / "kill.sh";
+  write_script(kill_script, "#!/bin/sh\n"
+                            "dir='" +
+                                queuedirectory.string() + "'\n"
+                                                  "touch \"$dir/$1.killed\"\n");
+
+  auto backendfile = sjef::expand_path((fs::path{backenddirectory} / "backends.xml").string());
+  for (const auto& [backend_name, host] : std::map<std::string, std::string>{{"local", ""}, {"remote", "127.0.0.1"}}) {
+    std::ofstream(backendfile) << "<?xml version=\"1.0\"?>\n<backends>\n"
+                               << "<backend name=\"" << backend_name << "\""
+                               << (host.empty() ? "" : " host=\"" + host + "\"") << "\n"
+                               << "         run_command=\"" << submit_script.string() << "\"\n"
+                               << "         run_jobnumber=\"Job ([0-9]+) submitted\"\n"
+                               << "         status_command=\"" << status_script.string() << "\"\n"
+                               << "         status_running=\"running\" status_waiting=\"queued\"\n"
+                               << "         kill_command=\"" << kill_script.string() << "\"/>\n"
+                               << "</backends>" << std::endl;
+    sjef::Project p(testproject("scripted_batch_backend_" + backend_name));
+    { std::ofstream(p.filename("inp")) << ""; }
+
+    ASSERT_TRUE(p.run(backend_name, 0, true, false));
+    const auto& jobnumber = p.property_get("jobnumber");
+    EXPECT_NE(jobnumber, "");
+    EXPECT_NE(jobnumber, "0");
+    EXPECT_NE(jobnumber, "-1");
+
+    // The job is a fake scheduler entry that runs for job_duration_seconds; at every sample taken
+    // before that has elapsed, status must still be running (or, early on, waiting) -- never completed.
+    // This is the regression this test exists for: a status_command whose output doesn't happen to
+    // repeat the job number gets silently misread as "the job isn't there", and a run_jobnumber that
+    // collides with the library's default sentinel gets the wrong quantity tracked as the job id
+    // altogether -- both of which previously made status jump straight to completed here, long before
+    // the fake job's elapsed-time clock says it should.
+    using namespace std::chrono;
+    for (int sample_ms : {300, 900, 1500, 2100}) {
+      std::this_thread::sleep_for(milliseconds(300));
+      EXPECT_THAT(p.status(), ::testing::AnyOf(sjef::status::running, sjef::status::waiting))
+          << "backend=" << backend_name << ", sample=" << sample_ms << "ms";
+    }
+
+    auto deadline = steady_clock::now() + seconds(job_duration_seconds + 10);
+    while (p.status() != sjef::status::completed && steady_clock::now() < deadline)
+      std::this_thread::sleep_for(milliseconds(100));
+    EXPECT_EQ(p.status(), sjef::status::completed) << "backend=" << backend_name;
+  }
 }


### PR DESCRIPTION
## Summary
- `Shell::run_local_sync()` unconditionally tried to read the child's stdout/stderr back from `m_out`/`m_err` even when output had been redirected straight to files (the case for a job submission command) -- that read blocked for the full 30s idle timeout and then threw, hanging and crashing any *local* backend that submits to a batch scheduler (i.e. any backend whose `run_jobnumber` is distinct from the library's built-in default `"([0-9]+)"`).
- `Shell::run_remote_sync()` only waited for the remote command to actually finish when capturing its output via pipe; when redirecting to files it returned as soon as the command was handed to the persistent ssh session's stdin, racing `pull_rundir()` and the `run_jobnumber` regex match immediately afterward. This broke batch submission for any backend reached over ssh, including a Slurm-style backend with `host: localhost`.
- Added `scripted_batch_backend`, a Molpro- and `ts`-independent regression test (fake scheduler built from three tiny shell scripts sharing a timestamp-file queue, deliberately avoiding backgrounded processes so the test itself can't race) covering both the local and ssh-loopback (`host: 127.0.0.1`) code paths.

Found while diagnosing a real-world backend wrapping the `task-spool` (`ts`) batch spooler, where status monitoring immediately reported "completed" for a job that was still running.

## Test plan
- [x] `test-sjef` (36 tests, including the new `scripted_batch_backend`) passes
- [x] `test-sjef-c`, `test-backend-config`, `test-sjef-molpro` all pass
- [x] Manually confirmed `scripted_batch_backend` reproduces both hangs against the pre-fix code and passes after the fix
- [x] Manually verified against a real local batch-spooler backend that status now correctly tracks Running for a job's real duration and only reports Completed once it actually finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)