### PR TITLE
Serialize the process-wide chdir used to launch/poll local jobs

### DIFF
--- a/src/sjef/util/Shell.cpp
+++ b/src/sjef/util/Shell.cpp
@@ -179,8 +179,24 @@ std::vector<std::string> tokenise(const std::string& command) {
   return tokens;
 }
 
+// fs::current_path() is process-wide state, not thread-local, so every place that saves it, chdir()s
+// to a target directory to spawn a child there, and restores it afterwards (run_local_sync() and
+// run_local_async() below) must run as one atomic unit with respect to every other thread doing the
+// same thing -- including Job::poll_job()'s free-running background thread, which is already active
+// for any other Job whose subprocess hasn't exited yet and fires this same save/chdir/restore
+// sequence (with directory=".") on every status-check cycle. Each of run_local_sync/run_local_async
+// is called via a *different* Shell instance per Job, and Shell's own m_run_mutex is per-instance, so
+// it does nothing to prevent this. Without a single process-wide lock, one thread's restore can land
+// between another thread's chdir() and its subprocess spawn, silently launching that subprocess (e.g.
+// Molpro itself, given a bare relative input filename) in the wrong directory. Only the brief
+// spawn/read/restore dance needs to be serialized, not the child's subsequent execution -- once
+// spawned (and, for the async case, detached), the child runs independently of this lock, so actual
+// job runtimes still overlap.
+static std::mutex g_current_path_mutex;
+
 void Shell::run_local_sync(const std::string& command, const std::string& directory, int verbosity,
                            const std::string& out, const std::string& err) const {
+  std::unique_lock<std::mutex> current_path_lock(g_current_path_mutex);
   auto wait = true;
   fs::path current_path_save;
   try {
@@ -259,6 +275,10 @@ void Shell::run_local_sync(const std::string& command, const std::string& direct
     }
   }
   fs::current_path(current_path_save);
+  // Nothing from here on touches the cwd, so release the lock now rather than holding it (and
+  // blocking every other thread's launch/status-check) for however long this command's own process
+  // takes to actually exit.
+  current_path_lock.unlock();
   m_process.wait();
   if (m_process.exit_code()) {
     throw runtime_error((std::string{"Shell(\""} + command +
@@ -293,6 +313,7 @@ void Shell::capture_job_number_from_error(const std::string& command) const {
 
 void Shell::run_local_async(const std::string& command, const std::string& directory, int verbosity,
                             const std::string& out) const {
+  std::lock_guard<std::mutex> current_path_lock(g_current_path_mutex);
   fs::path current_path_save;
   try {
     current_path_save = fs::current_path();


### PR DESCRIPTION
## Summary
- `Shell::run_local_sync()`/`run_local_async()` each save the process cwd, `chdir()` into the target run directory to spawn a child there, and restore the saved cwd afterwards. `fs::current_path()` is process-wide state, not thread-local. Every `Job::run()` spawns its own free-running `poll_job()` background thread (`std::async`) that keeps calling `run_local_sync()` with `directory="."` on every status-check cycle for as long as that job is in flight.
- With several local jobs in flight at once (e.g. `pymolpro`'s `database.run()`, which launches a batch of Molpro jobs from a thread pool), one thread's restore-to-saved-cwd can land between *another* thread's `chdir()` and its subprocess spawn. The second job then launches with the wrong cwd — and since sjef hands Molpro a bare relative input filename (relying entirely on cwd to find it), the process fails immediately with `input file ... does not exist`, and its stdout/output ends up wherever cwd happened to be. `Shell`'s own `m_run_mutex` is per-instance, and every `Job` uses its own `Shell`, so it does nothing to prevent this.
- Fix: guard both functions' chdir/spawn/restore sequence with one process-wide `std::mutex`. Only that brief sequence is serialized, not the child's actual runtime — the lock is released right after cwd is restored (before waiting on the child's own exit, for the sync case), so concurrently launched jobs still execute in parallel once spawned.
- Diagnosed by reproducing the failure via `pymolpro`'s `database.run()` (a thread-pool batch of local Molpro jobs) and confirming, via `nm -u` on the compiled library and reading through `Job.cpp`, that the only place touching `fs::current_path()`'s setter is this save/chdir/restore pattern in `Shell.cpp`, invoked concurrently from both job launches and the free-running per-job status-poll thread.

## Test plan
- [x] `test/test-Shell` — all 9 tests pass.
- [x] `test/test-sjef` — all 36 tests pass (including `many_projects` and `spawn_many_dummy`, the concurrency-relevant cases).
- [x] Built this fix into `pysjef` and ran `pymolpro`'s `database.run()` reproduction (a thread-pool batch of ~15 local Molpro jobs) from a clean directory 11 times in a row with no failures — previously this failed roughly 40-50% of the time with "input file ... does not exist" / malformed-XML errors. Confirmed the fix does not serialize actual job execution: batch wall-clock time was unchanged (~7-8s, consistent with true parallel execution), and the fix works even with no additional locking on the Python side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)